### PR TITLE
Accept user input for message sent to test chat room

### DIFF
--- a/serif_cli/src/main/kotlin/serif_cli/App.kt
+++ b/serif_cli/src/main/kotlin/serif_cli/App.kt
@@ -48,9 +48,13 @@ class App {
                     m.getRoom()
                 }
                 is MatrixChatRoom -> {
-                    println("Entered Room! Enter Test Message")
+                    print("Message> ")
                     val msg = console.readLine()
-                    m.sendMessage(msg)
+                    if(msg == ":q") {
+                        m.exitRoom()
+                    } else {
+                        m.sendMessage(msg)
+                    }
                 }
             }
         }

--- a/serif_cli/src/main/kotlin/serif_cli/App.kt
+++ b/serif_cli/src/main/kotlin/serif_cli/App.kt
@@ -44,8 +44,13 @@ class App {
                     m.login(username, password)
                 }
                 is MatrixRooms -> {
-                    println("Logged in! Sending test message")
-                    m.test()
+                    println("Logged in! Getting Room")
+                    m.getRoom()
+                }
+                is MatrixChatRoom -> {
+                    println("Entered Room! Enter Test Message")
+                    val msg = console.readLine()
+                    m.sendMessage(msg)
                 }
             }
         }

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/MatrixClient.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/MatrixClient.kt
@@ -57,25 +57,40 @@ class MatrixRooms(val msession: MatrixSession): MatrixState() {
 }
 class MatrixChatRoom(val msession: MatrixSession): MatrixState() {
     fun sendMessage(msg : String): MatrixState {
-        return MatrixLogin("${msession.test(msg)}, now going back to login for now\n", MatrixClient())
+        when (val sendMessageResult = msession.sendMessage(msg)) {
+            is Success -> { println("${sendMessageResult.value}") }
+            is Error -> { println("${sendMessageResult.message} - exception was ${sendMessageResult.cause}") }
+        }
+        return this
+    }
+    fun exitRoom(): MatrixState {
+        msession.closeSession()
+        return MatrixLogin("Closing session, returning to the login prompt for now\n", MatrixClient())
     }
 }
 class MatrixSession(val client: HttpClient, val access_token: String) {
-    fun test(msg : String): String {
+    fun sendMessage(msg : String): Outcome<String> {
+        try {
 
-        val result = runBlocking {
+            val result = runBlocking {
 
-            val room_id = "!bwqkmRobBXpTSDiGIw:synapse.room409.xyz"
-            val message_confirmation = client.put<EventIdResponse>("https://synapse.room409.xyz/_matrix/client/r0/rooms/$room_id/send/m.room.message/23?access_token=$access_token") {
-                contentType(ContentType.Application.Json)
-                body = RoomMessage(msg)
+                val room_id = "!bwqkmRobBXpTSDiGIw:synapse.room409.xyz"
+                val message_confirmation = client.put<EventIdResponse>("https://synapse.room409.xyz/_matrix/client/r0/rooms/$room_id/send/m.room.message/23?access_token=$access_token") {
+                    contentType(ContentType.Application.Json)
+                    body = RoomMessage(msg)
+                }
+                message_confirmation.event_id
             }
-            message_confirmation.event_id
-        }
 
+            return Success("Hello, ${Platform().platform}, ya cowpeople! - Our sent event id is: $result")
+        } catch (e: Exception) {
+            return Error("Message Send Failed", e)
+        }
+    }
+
+    fun closeSession() {
         // TO ACT LIKE A LOGOUT, CLOSING THE CLIENT
         client.close()
-        return "Hello, ${Platform().platform}, ya cowpeople! - Our sent event id is: $result"
     }
 }
 

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/MatrixClient.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/MatrixClient.kt
@@ -51,19 +51,24 @@ class MatrixLogin(val login_message: String, val mclient: MatrixClient): MatrixS
     }
 }
 class MatrixRooms(val msession: MatrixSession): MatrixState() {
-    fun test(): MatrixState {
-        return MatrixLogin("${msession.test()}, now going back to login for now\n", MatrixClient())
+    fun getRoom(): MatrixState {
+        return MatrixChatRoom(msession)
+    }
+}
+class MatrixChatRoom(val msession: MatrixSession): MatrixState() {
+    fun sendMessage(msg : String): MatrixState {
+        return MatrixLogin("${msession.test(msg)}, now going back to login for now\n", MatrixClient())
     }
 }
 class MatrixSession(val client: HttpClient, val access_token: String) {
-    fun test(): String {
+    fun test(msg : String): String {
 
         val result = runBlocking {
 
             val room_id = "!bwqkmRobBXpTSDiGIw:synapse.room409.xyz"
             val message_confirmation = client.put<EventIdResponse>("https://synapse.room409.xyz/_matrix/client/r0/rooms/$room_id/send/m.room.message/23?access_token=$access_token") {
                 contentType(ContentType.Application.Json)
-                body = RoomMessage("Final version - for now.....")
+                body = RoomMessage(msg)
             }
             message_confirmation.event_id
         }


### PR DESCRIPTION
Mostly resolves issue #6. Adds a new state, MatrixChatRoom, to indicate being in a specific room and has a sendMessage method which takes a string which it passes to the MatrixSession for use in making the message request to the server. The old MatrixRooms state I assumed would be the state for getting a list of rooms, and I changed its test method to be getRoom which for now just passes us through to the MatrixChatRoom state while the test room is still being used.

Unlike the use case described in the issue, the user input is prompted for in the cli app on arrival to the chat room state and is not activated by typing `send` followed by a message.