### PR TITLE
Don't fail if test dir already exists. Ignore test dir.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@ local.properties
 serif_android/build
 serif_cli/build
 serif_shared/build
+test/
 *.swp

--- a/run_dist.sh
+++ b/run_dist.sh
@@ -1,2 +1,8 @@
 #!/usr/bin/env bash
-./gradlew :serif_cli:assembleDist && mkdir test && cd test && tar xf ../serif_cli/build/distributions/serif_cli.tar && ./serif_cli/bin/serif_cli && cd .. && rm -r test
+
+#make test dir if it doesn't exist
+if [ ! -d test ]; then
+    mkdir test
+fi
+
+./gradlew :serif_cli:assembleDist && cd test && tar xf ../serif_cli/build/distributions/serif_cli.tar && ./serif_cli/bin/serif_cli && cd .. && rm -r test

--- a/run_dist.sh
+++ b/run_dist.sh
@@ -1,8 +1,2 @@
 #!/usr/bin/env bash
-
-#make test dir if it doesn't exist
-if [ ! -d test ]; then
-    mkdir test
-fi
-
-./gradlew :serif_cli:assembleDist && cd test && tar xf ../serif_cli/build/distributions/serif_cli.tar && ./serif_cli/bin/serif_cli && cd .. && rm -r test
+./gradlew :serif_cli:assembleDist && mkdir -p test && cd test && tar xf ../serif_cli/build/distributions/serif_cli.tar && ./serif_cli/bin/serif_cli && cd .. && rm -r test


### PR DESCRIPTION
Fix helper script to not fail if the test dir already exists. If it does, mkdir would fail and the application wouldn't run.