### PR TITLE
Syncing

### DIFF
--- a/serif_cli/src/main/kotlin/serif_cli/App.kt
+++ b/serif_cli/src/main/kotlin/serif_cli/App.kt
@@ -45,19 +45,32 @@ class App {
                 }
                 is MatrixRooms -> {
                     println(m.message)
-                    println(m.rooms)
-                    print("Input a room number or :sync>")
+                    m.rooms.forEachIndexed { i, (id,name) ->
+                        println("$i - $id - $name")
+                    }
+                    print("Input a room number, :sync, or :q> ")
                     val msg = console.readLine()
                     if(msg == ":sync") {
                         m.sync()
+                    } else if(msg == ":q") {
+                        m.fake_logout()
                     } else {
-                        m.getRoom()
+                        val selection = msg.toIntOrNull()
+                        if (selection != null && selection >= 0 && selection < m.rooms.size) {
+                            m.getRoom(m.rooms[selection].first)
+                        } else {
+                            println("Bad number $msg, try again")
+                            m
+                        }
                     }
                 }
                 is MatrixChatRoom -> {
-                    print("Message> ")
+                    m.messages.forEach { message ->
+                        println("-$message")
+                    }
+                    print("Message (or :b)> ")
                     val msg = console.readLine()
-                    if(msg == ":q") {
+                    if(msg == ":b") {
                         m.exitRoom()
                     } else {
                         m.sendMessage(msg)

--- a/serif_cli/src/main/kotlin/serif_cli/App.kt
+++ b/serif_cli/src/main/kotlin/serif_cli/App.kt
@@ -44,8 +44,15 @@ class App {
                     m.login(username, password)
                 }
                 is MatrixRooms -> {
-                    println("Logged in! Getting Room")
-                    m.getRoom()
+                    println(m.message)
+                    println(m.rooms)
+                    print("Input a room number or :sync>")
+                    val msg = console.readLine()
+                    if(msg == ":sync") {
+                        m.sync()
+                    } else {
+                        m.getRoom()
+                    }
                 }
                 is MatrixChatRoom -> {
                     print("Message> ")

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Events.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Events.kt
@@ -1,0 +1,140 @@
+package xyz.room409.serif.serif_shared
+
+import kotlinx.serialization.*
+import kotlinx.serialization.json.*
+
+@Serializable
+data class LoginRequest(val type: String, val identifier: LoginIdentifier, val password: String, val initial_device_display_name: String) {
+    constructor(username: String, password: String): this(type="m.login.password",
+                                                          identifier=LoginIdentifier(type="m.id.user",user=username),
+                                                          password=password,
+                                                          initial_device_display_name="Serif")
+}
+@Serializable
+data class LoginIdentifier(val type: String, val user: String)
+
+@Serializable
+data class LoginResponse(val access_token: String)
+
+@Serializable
+data class SendRoomMessage(val msgtype: String, val body: String) {
+    constructor(body: String): this(msgtype="m.text",body=body)
+}
+@Serializable
+data class EventIdResponse(val event_id: String)
+
+@Serializable
+data class SyncResponse(var next_batch: String, val rooms: Rooms)
+@Serializable
+data class Rooms(val join: MutableMap<String, Room>)
+@Serializable
+data class Room(var timeline: Timeline, var state: State, val summary: RoomSummary)
+@Serializable
+data class Timeline(var events: List<Event>, val prev_batch: String)
+@Serializable
+data class State(val events: List<Event>)
+@Serializable
+data class RoomSummary(@SerialName("m.heroes") val heroes: List<String>? = null,
+                       @SerialName("m.joined_member_count") val joined_member_count: Long? = null,
+                       @SerialName("m.invited_member_count") val invited_member_count: Long? = null)
+
+@Serializable(with = EventSerializer::class)
+abstract class Event {
+    abstract val raw_self: JsonObject
+    abstract val raw_content: JsonElement
+    abstract val type: String
+}
+abstract class RoomEvent: Event() {
+    abstract val event_id: String
+    abstract val sender: String
+    abstract val origin_server_ts: Long
+    abstract val unsigned: UnsignedData?
+}
+@Serializable
+data class UnsignedData(val age: Long? = null, /*redacted_because: Event?,*/ val transaction_id: String? = null)
+@Serializable
+class StateEvent<T>(
+                        override val raw_self:          JsonObject,
+                        override val raw_content:       JsonElement,
+                        override val type:              String,
+                        override val event_id:          String,
+                        override val sender:            String,
+                        override val origin_server_ts:  Long,
+                        override val unsigned:          UnsignedData? = null,
+                                 val state_key:         String,
+                                 /*val prev_content: EventContent?*/
+                                 val content:           T,
+                        ): RoomEvent() {
+    override fun toString() = "RoomNameEvent(" + raw_self.toString() + ")"
+}
+@Serializable
+class RoomNameContent(val name: String)
+@Serializable
+class RoomCanonicalAliasContent(val alias: String? = null, val alt_aliases: List<String>? = null)
+
+// RoomMessageEvent and RoomMessageEventContent should eventually be generic on message type
+@Serializable
+class RoomMessageEvent(
+                        override val raw_self:          JsonObject,
+                        override val raw_content:       JsonElement,
+                        override val type:              String,
+                        override val event_id:          String,
+                        override val sender:            String,
+                        override val origin_server_ts:  Long,
+                        override val unsigned:          UnsignedData? = null,
+                                 val content:           RoomMessageEventContent
+                        ): RoomEvent() {
+    override fun toString() = "RoomMessageEvent(" + raw_self.toString() + ")"
+}
+@Serializable
+class RoomMessageEventContent(val body: String, val msgtype: String)
+
+@Serializable
+class EventFallback(
+                        override val raw_self: JsonObject,
+                        override val raw_content: JsonElement,
+                        override val type: String
+                   ): Event() {
+    override fun toString() = "EventFallback(" + raw_self.toString() + ")"
+}
+@Serializable
+class RoomEventFallback(
+                        override val raw_self:          JsonObject,
+                        override val raw_content:       JsonElement,
+                        override val type:              String,
+                        override val event_id:          String,
+                        override val sender:            String,
+                        override val origin_server_ts:  Long,
+                        override val unsigned:          UnsignedData? = null
+                        ): RoomEvent() {
+    override fun toString() = "RoomEventFallback(" + raw_self.toString() + ")"
+}
+
+
+object EventSerializer : JsonContentPolymorphicSerializer<Event>(Event::class) {
+    override fun selectDeserializer(element: JsonElement) = element.jsonObject["type"]!!.jsonPrimitive.content.let { type -> when {
+        type == "m.room.message"            -> RoomMessageEventSerializer
+        type == "m.room.name"               -> RoomNameStateEventSerializer
+        type == "m.room.canonical_alias"    -> RoomCanonicalAliasStateEventSerializer
+        type.startsWith("m.room")           -> RoomEventFallbackSerializer
+        else                                -> EventFallbackSerializer
+    } }
+}
+
+object EventFallbackSerializer : GenericJsonEventSerializer<EventFallback>(EventFallback.serializer()) { }
+object RoomEventFallbackSerializer : GenericJsonEventSerializer<RoomEventFallback>(RoomEventFallback.serializer()) { }
+object RoomMessageEventSerializer : GenericJsonEventSerializer<RoomMessageEvent>(RoomMessageEvent.serializer()) { }
+object RoomNameStateEventSerializer : GenericJsonEventSerializer<StateEvent<RoomNameContent>>(StateEvent.serializer(RoomNameContent.serializer())) { }
+object RoomCanonicalAliasStateEventSerializer : GenericJsonEventSerializer<StateEvent<RoomCanonicalAliasContent>>(StateEvent.serializer(RoomCanonicalAliasContent.serializer())) { }
+
+open class GenericJsonEventSerializer<T: Any>(clazz: KSerializer<T>): JsonTransformingSerializer<T>(clazz) {
+    override fun transformDeserialize(element: JsonElement): JsonElement = buildJsonObject {
+        put("raw_self", element)
+        put("raw_content", element.jsonObject["content"]!!)
+        for ((key, value) in element.jsonObject) {
+            put(key, value)
+        }
+    }
+    override fun transformSerialize(element: JsonElement): JsonElement =
+        element.jsonObject["raw_self"]!!
+}

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/MatrixClient.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/MatrixClient.kt
@@ -2,148 +2,38 @@ package xyz.room409.serif.serif_shared
 import kotlinx.coroutines.*
 import io.ktor.client.*
 import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.client.features.json.*
 import io.ktor.client.features.json.serializer.KotlinxSerializer
 import io.ktor.http.*
-import kotlinx.serialization.*
-import kotlinx.serialization.json.*
 
 sealed class Outcome<out T : Any> { }
 data class Success<out T : Any>(val value: T) : Outcome<T>()
 data class Error(val message: String, val cause: Exception? = null) : Outcome<Nothing>()
 
-@Serializable
-data class LoginRequest(val type: String, val identifier: LoginIdentifier, val password: String, val initial_device_display_name: String) {
-    constructor(username: String, password: String): this(type="m.login.password",
-                                                          identifier=LoginIdentifier(type="m.id.user",user=username),
-                                                          password=password,
-                                                          initial_device_display_name="Serif")
-}
-@Serializable
-data class LoginIdentifier(val type: String, val user: String)
+// Returns the first Event of class T, or null
+inline fun <reified T> List<Event>.firstOfType(): T? = this.map { (it as? T?) }.firstOrNull { it != null }
 
-@Serializable
-data class LoginResponse(val access_token: String)
-
-@Serializable
-data class SendRoomMessage(val msgtype: String, val body: String) {
-    constructor(body: String): this(msgtype="m.text",body=body)
-}
-@Serializable
-data class EventIdResponse(val event_id: String)
-
-@Serializable
-data class SyncResponse(var next_batch: String, val rooms: Rooms)
-@Serializable
-data class Rooms(val join: MutableMap<String, Room>)
-@Serializable
-data class Room(val timeline: Timeline)
-@Serializable
-data class Timeline(val events: List<Event>, val prev_batch: String)
-
-@Serializable(with = EventSerializer::class)
-abstract class Event {
-    abstract val self: JsonObject
-    abstract val content: JsonElement
-    abstract val type: String
-}
-
-object EventSerializer : JsonContentPolymorphicSerializer<Event>(Event::class) {
-    override fun selectDeserializer(element: JsonElement) = when {
-        else -> EventFallbackSerializer
-    }
-}
-
-abstract class RoomEvent: Event() {
-    abstract val event_id: String
-    abstract val sender: String
-    abstract val origin_server_ts: Long
-    abstract val unsigned: UnsignedData?
-}
-
-@Serializable
-data class UnsignedData(val age: Long?, /*redacted_because: Event?,*/ val transaction_id: String?)
-
-abstract class StateEvent: RoomEvent() {
-    abstract val state_key: String
-    /*abstract val prev_content: EventContent?*/
-}
-
-abstract class RoomMessage: RoomEvent() {
-    abstract val body: String
-    abstract val msgtype: String
-}
-
-//@Serializable
-//class RoomMessageFallback(val self: JsonObject): RoomMessage()
-//@Serializable
-//class RoomEventFallback(val self: JsonObject): RoomEvent()
-@Serializable
-class EventFallback(override val self: JsonObject, override val content: JsonElement, override val type: String): Event() {
-    override fun toString() = self.toString()
-}
-
-object EventFallbackSerializer : JsonTransformingSerializer<EventFallback>(EventFallback.serializer()) {
-    override fun transformDeserialize(element: JsonElement): JsonElement = buildJsonObject {
-        put("self", element)
-        put("content", element.jsonObject["content"]!!)
-        put("type", element.jsonObject["type"]!!)
-    }
-    override fun transformSerialize(element: JsonElement): JsonElement =
-        element.jsonObject["self"]!!
-}
-
-
-
-sealed class MatrixState {
-    val version: String
-        get() {
-            return "Serif Matrix client, pre-alpha on ${Platform().platform}"
-        }
-}
-class MatrixLogin(val login_message: String, val mclient: MatrixClient): MatrixState() {
-    constructor(): this(login_message="Please enter your username and password\n",
-                        mclient=MatrixClient())
-    fun login(username: String, password: String): MatrixState {
-        when (val loginResult = mclient.login(username, password)) {
-            is Success -> { return MatrixRooms(msession=loginResult.value, rooms=listOf(), message="Logged in! Maybe try syncing?") }
-            is Error -> { return MatrixLogin(login_message="${loginResult.message} - exception was ${loginResult.cause}, please login again...\n",
-                                             mclient=mclient) }
-        }
-    }
-}
-class MatrixRooms(val msession: MatrixSession, val rooms: List<String>, val message: String): MatrixState() {
-    fun sync(): MatrixState {
-        when (val syncResult = msession.sync()) {
-            is Success -> { return MatrixRooms(msession=msession, rooms=msession.sync_response?.rooms?.join?.keys?.toList() ?: listOf(),
-                                               message="Sync success\n") }
-            is Error   -> { return MatrixRooms(msession=msession, rooms=rooms,
-                                               message="${syncResult.message} - exception was ${syncResult.cause}, maybe try again?\n") }
-        }
-    }
-    fun getRoom(): MatrixState {
-        return MatrixChatRoom(msession)
-    }
-}
-class MatrixChatRoom(val msession: MatrixSession): MatrixState() {
-    fun sendMessage(msg : String): MatrixState {
-        when (val sendMessageResult = msession.sendMessage(msg)) {
-            is Success -> { println("${sendMessageResult.value}") }
-            is Error -> { println("${sendMessageResult.message} - exception was ${sendMessageResult.cause}") }
-        }
-        return this
-    }
-    fun exitRoom(): MatrixState {
-        msession.closeSession()
-        return MatrixLogin("Closing session, returning to the login prompt for now\n", MatrixClient())
-    }
-}
 class MatrixSession(val client: HttpClient, val access_token: String) {
     var sync_response: SyncResponse? = null
-    fun sendMessage(msg : String): Outcome<String> {
+
+    // rooms is a pair of room_id and room display name
+    // Display name is calculated by first checking for a room name event in the state events,
+    // then for a canonical alias in the state events, then a list of hero users in the room summary,
+    // and then the error message. Technically we should also be looking at timeline events
+    // for room name changes too. Also, it's not working when there's not a room name -
+    // the way I'm reading the doc heros should be non-null... maybe it's not decoding right?
+    val rooms: List<Pair<String,String>>
+        get() = sync_response?.rooms?.join?.entries?.map { (id, room) ->
+            Pair(id, (room.state.events.firstOfType<StateEvent<RoomNameContent>>()?.content?.name
+                   ?: room.state.events.firstOfType<StateEvent<RoomCanonicalAliasContent>>()?.content?.alias
+                   ?: room.summary.heroes?.joinToString(", ")
+                   ?: "<no room name or heroes>"))
+        }?.toList() ?: listOf()
+
+    fun sendMessage(msg: String, room_id: String): Outcome<String> {
         try {
             val result = runBlocking {
-                val room_id = "!bwqkmRobBXpTSDiGIw:synapse.room409.xyz"
                 val message_confirmation = client.put<EventIdResponse>("https://synapse.room409.xyz/_matrix/client/r0/rooms/$room_id/send/m.room.message/23?access_token=$access_token") {
                     contentType(ContentType.Application.Json)
                     body = SendRoomMessage(msg)
@@ -175,9 +65,16 @@ class MatrixSession(val client: HttpClient, val access_token: String) {
                 if (sync_response != null) {
                     println("Sync response wasn't null")
                     for ((room_id, room) in new_sync_response.rooms.join) {
-                        println(" adding in new room_id and room")
-                        // Do a better combine
-                        sync_response!!.rooms.join[room_id] = room
+                        if (sync_response!!.rooms.join.containsKey(room_id)) {
+                            // This should actually be updated with messages from the timeline too
+                            sync_response!!.rooms.join[room_id]!!.state = room.state
+                            // This also needs to be changed to something that supports discontinuous
+                            // sections of timeline with different prev_patch, etc
+                            sync_response!!.rooms.join[room_id]!!.timeline.events += room.timeline.events
+                        } else {
+                            println(" adding in new room_id and room")
+                            sync_response!!.rooms.join[room_id] = room
+                        }
                     }
                     sync_response!!.next_batch = new_sync_response.next_batch
                 } else {

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
@@ -1,0 +1,52 @@
+package xyz.room409.serif.serif_shared
+import kotlin.collections.*
+
+sealed class MatrixState {
+    val version: String
+        get() {
+            return "Serif Matrix client, pre-alpha on ${Platform().platform}"
+        }
+}
+class MatrixLogin(val login_message: String, val mclient: MatrixClient): MatrixState() {
+    constructor(): this(login_message="Please enter your username and password\n",
+                        mclient=MatrixClient())
+    fun login(username: String, password: String): MatrixState {
+        when (val loginResult = mclient.login(username, password)) {
+            is Success -> { return MatrixRooms(msession=loginResult.value, rooms=listOf(), message="Logged in! Maybe try syncing?") }
+            is Error -> { return MatrixLogin(login_message="${loginResult.message} - exception was ${loginResult.cause}, please login again...\n",
+                                             mclient=mclient) }
+        }
+    }
+}
+class MatrixRooms(val msession: MatrixSession, val rooms: List<Pair<String, String>>, val message: String): MatrixState() {
+    fun sync(): MatrixState {
+        when (val syncResult = msession.sync()) {
+            is Success -> { return MatrixRooms(msession=msession, rooms=msession.rooms,
+                                               message="Sync success\n") }
+            is Error   -> { return MatrixRooms(msession=msession, rooms=rooms,
+                                               message="${syncResult.message} - exception was ${syncResult.cause}, maybe try again?\n") }
+        }
+    }
+    fun getRoom(id: String): MatrixState {
+        return MatrixChatRoom(msession,
+                              id,
+                              msession.sync_response!!.rooms.join[id]!!.timeline.events.map { (it as? RoomMessageEvent)?.content?.body }.filterNotNull())
+    }
+    fun fake_logout(): MatrixState {
+        msession.closeSession()
+        return MatrixLogin("Closing session, returning to the login prompt for now\n", MatrixClient())
+    }
+}
+class MatrixChatRoom(val msession: MatrixSession, val room_id: String, val messages: List<String>): MatrixState() {
+    fun sendMessage(msg : String): MatrixState {
+        when (val sendMessageResult = msession.sendMessage(msg, room_id)) {
+            is Success -> { println("${sendMessageResult.value}") }
+            is Error -> { println("${sendMessageResult.message} - exception was ${sendMessageResult.cause}") }
+        }
+        return this
+    }
+    fun exitRoom(): MatrixState {
+        return MatrixRooms(msession, msession.rooms, "Back to rooms. You can still do a :sync...")
+    }
+}
+


### PR DESCRIPTION
Mostly finishes #7, doesn't actually show count of unread messages (though that might not be too hard to add, after getting all this sync deserialization machinery going).
This PR splits the code out into MatrixClient.kt, Events.kt, and States.kt.
It also adds a bunch of classes and code to Events.kt to deserialize sync responses in a flexible way.
It has an Event class hierarchy mostly following the spec with raw_self members with the actual JsonElement of the event alongside the deserailized members. StateEvents are also generic on their containing content type, a strategy I intend to use on the RoomMessageEvent(s) as we add more than just basic text.
There's a lot to do that just has skeletons or placeholders for now, like merging a new SyncResponse with your current one.
It's pretty late so I might not have explained everything the best, but ask away question-wise!