### PR TITLE
Image support

### DIFF
--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Database.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Database.kt
@@ -47,11 +47,17 @@ object Database {
         return cached_img
     }
 
-    fun addImageToCache(url: String, file_data: ByteArray): String {
-        val file = File.createTempFile("media_", ".img")
+    fun addImageToCache(url: String, file_data: ByteArray, update: Boolean): String {
+        val cache_path = File(System.getProperty("user.dir") + "/cache/images/")
+        cache_path.mkdirs()
+        val file = File.createTempFile("media_", "img", cache_path)
         file.outputStream().write(file_data)
         val local = file.toPath().toString()
-        this.db?.sessionDbQueries?.insertMedia(url, local)
+        if(update) {
+            this.db?.sessionDbQueries?.updateMedia(local, url)
+        } else {
+            this.db?.sessionDbQueries?.insertMedia(url, local)
+        }
         return local
     }
 }

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Database.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Database.kt
@@ -48,7 +48,7 @@ object Database {
     }
 
     fun addImageToCache(url: String, file_data: ByteArray): String {
-        val file = File.createTempFile("media_",".img")
+        val file = File.createTempFile("media_", ".img")
         file.outputStream().write(file_data)
         val local = file.toPath().toString()
         this.db?.sessionDbQueries?.insertMedia(url, local)

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Database.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Database.kt
@@ -2,6 +2,7 @@ package xyz.room409.serif.serif_shared
 import xyz.room409.serif.serif_shared.db.*
 import xyz.room409.serif.serif_shared.db.DriverFactory
 import xyz.room409.serif.serif_shared.db.SessionDb
+import java.io.File
 
 object Database {
     // See platform specific code in serif_shared for the
@@ -37,5 +38,20 @@ object Database {
 
     fun deleteAllSessions() {
         this.db?.sessionDbQueries?.deleteAllSessions()
+    }
+
+    fun getImageInCache(url: String): String? {
+        val cached_img = this.db?.sessionDbQueries?.selectCachedMedia(url) { mxcUrl: String, localPath: String ->
+            localPath
+        }?.executeAsOneOrNull()
+        return cached_img
+    }
+
+    fun addImageToCache(url: String, file_data: ByteArray): String {
+        val file = File.createTempFile("media_",".img")
+        file.outputStream().write(file_data)
+        val local = file.toPath().toString()
+        this.db?.sessionDbQueries?.insertMedia(url, local)
+        return local
     }
 }

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Events.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Events.kt
@@ -98,8 +98,11 @@ class RoomMessageEvent(
     override fun toString() = "RoomMessageEvent(" + raw_self.toString() + ")"
 }
 @Serializable
-class RoomMessageEventContent(val body: String = "<missing message body, likely redacted>", val msgtype: String = "<missing type, likely redacted>",
-                              val url: String? = null)
+class RoomMessageEventContent(
+    val body: String = "<missing message body, likely redacted>",
+    val msgtype: String = "<missing type, likely redacted>",
+    val url: String? = null
+)
 
 @Serializable
 class EventFallback(

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Events.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Events.kt
@@ -23,6 +23,8 @@ data class SendRoomMessage(val msgtype: String, val body: String) {
     constructor(body: String) : this(msgtype = "m.text", body = body)
 }
 @Serializable
+data class MediaUploadResponse(val content_uri: String)
+@Serializable
 data class EventIdResponse(val event_id: String)
 @Serializable
 data class UnreadNotifications(val highlight_count: Int? = null, val notification_count: Int? = null)
@@ -96,7 +98,8 @@ class RoomMessageEvent(
     override fun toString() = "RoomMessageEvent(" + raw_self.toString() + ")"
 }
 @Serializable
-class RoomMessageEventContent(val body: String = "<missing message body, likely redacted>", val msgtype: String = "<missing type, likely redacted>")
+class RoomMessageEventContent(val body: String = "<missing message body, likely redacted>", val msgtype: String = "<missing type, likely redacted>",
+                              val url: String? = null)
 
 @Serializable
 class EventFallback(

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Events.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Events.kt
@@ -23,6 +23,17 @@ data class SendRoomMessage(val msgtype: String, val body: String) {
     constructor(body: String) : this(msgtype = "m.text", body = body)
 }
 @Serializable
+data class ImageInfo(val h: Int, val mimetype: String, val size: Int, val w: Int)
+@Serializable
+data class SendRoomImageMessage(val msgtype: String, val body: String, val info: ImageInfo, val url: String) {
+    constructor(body: String, info: ImageInfo, url: String) : this(
+        msgtype = "m.image",
+        body = body,
+        info = info,
+        url = url
+    )
+}
+@Serializable
 data class MediaUploadResponse(val content_uri: String)
 @Serializable
 data class EventIdResponse(val event_id: String)

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/MatrixClient.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/MatrixClient.kt
@@ -91,10 +91,13 @@ class MatrixSession(val client: HttpClient, val access_token: String, var transa
                 val img_f = File(url)
                 val image_data = img_f.readBytes()
                 val f_size = image_data.size
+                var ct = ContentType.Image.JPEG
                 val mimetype =
                     if(url.endsWith(".png")) {
+                        ct = ContentType.Image.PNG
                         "image/png"
                     } else if(url.endsWith(".gif")) {
+                        ct = ContentType.Image.GIF
                         "image/gif"
                     } else {
                         "image/jpeg"
@@ -104,7 +107,7 @@ class MatrixSession(val client: HttpClient, val access_token: String, var transa
                 //Post Image to server
                 val upload_img_response =
                     client.post<MediaUploadResponse>("https://synapse.room409.xyz/_matrix/media/r0/upload?access_token=$access_token") {
-                        contentType(ContentType.Image.Any)
+                        contentType(ct)
                         body = image_data
                     }
 

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/MatrixClient.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/MatrixClient.kt
@@ -56,8 +56,8 @@ class MatrixSession(val client: HttpClient, val access_token: String, var transa
     // for room name changes too. Also, it's not working when there's not a room name -
     // the way I'm reading the doc heroes should be non-null... maybe it's not decoding right?
 
-    fun <T> mapRooms(f: (String,Room) -> T): List<T> = synchronized(this) {
-        sync_response?.rooms?.join?.entries?.map{ (id,room,) -> f(id, room) }?.toList() ?: listOf()
+    fun <T> mapRooms(f: (String, Room) -> T): List<T> = synchronized(this) {
+        sync_response?.rooms?.join?.entries?.map { (id, room,) -> f(id, room) }?.toList() ?: listOf()
     }
     fun <T> mapRoom(id: String, f: (Room) -> T): T? = synchronized(this) {
         sync_response?.rooms?.join?.get(id)?.let { f(it) }
@@ -87,14 +87,14 @@ class MatrixSession(val client: HttpClient, val access_token: String, var transa
     fun getLocalImagePathFromUrl(image_url: String): Outcome<String> {
         try {
             val cached_img = Database.getImageInCache(image_url)
-            if(cached_img != null) {
+            if (cached_img != null) {
                 return Success(cached_img)
             } else {
                 val result = runBlocking {
                     val url = "https://synapse.room409.xyz/_matrix/media/r0/download/${image_url.replace("mxc://","")}"
                     println("Retrieving image from $url")
                     val media = client.get<ByteArray>(url)
-                    Database.addImageToCache(image_url,media)
+                    Database.addImageToCache(image_url, media)
                 }
                 println("Img file at $result")
                 return Success(result)

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/MatrixClient.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/MatrixClient.kt
@@ -91,7 +91,15 @@ class MatrixSession(val client: HttpClient, val access_token: String, var transa
                 val img_f = File(url)
                 val image_data = img_f.readBytes()
                 val f_size = image_data.size
-                val image_info = ImageInfo(0, "image/jpeg", f_size, 0)
+                val mimetype =
+                    if(url.endsWith(".png")) {
+                        "image/png"
+                    } else if(url.endsWith(".gif")) {
+                        "image/gif"
+                    } else {
+                        "image/jpeg"
+                    }
+                val image_info = ImageInfo(0, mimetype, f_size, 0)
 
                 //Post Image to server
                 val upload_img_response =

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
@@ -108,8 +108,9 @@ class MatrixChatRoom(private val msession: MatrixSession, val room_id: String, v
             }
         } else { null }
     }.filterNotNull()
-    fun sendMessage(msg: String): MatrixState {
-        when (val sendMessageResult = msession.sendMessage(msg, room_id)) {
+    fun sendMessage(msg: String, is_img: Boolean = false): MatrixState {
+        val sendFunc = if(is_img) { msession::sendImageMessage } else { msession::sendMessage }
+        when (val sendMessageResult = sendFunc(msg, room_id)) {
             is Success -> { println("${sendMessageResult.value}") }
             is Error -> { println("${sendMessageResult.message} - exception was ${sendMessageResult.cause}") }
         }

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
@@ -59,7 +59,7 @@ class MatrixRooms(private val msession: MatrixSession, val message: String) : Ma
             room.timeline.events.findLast { it as? RoomMessageEvent != null }?.let {
                 val it = it as RoomMessageEvent
                 SharedUiMessage(it.sender, it.content.body, it.event_id, it.origin_server_ts)
-           }
+            }
         )
     }.sortedBy { -(it.lastMessage?.timestamp ?: 0) }
     override fun refresh(): MatrixState = MatrixRooms(
@@ -78,18 +78,29 @@ class MatrixRooms(private val msession: MatrixSession, val message: String) : Ma
         return MatrixLogin("Closing session, returning to the login prompt for now\n", MatrixClient())
     }
 }
-data class SharedUiMessage(val sender: String, val message: String, val id: String, val timestamp: Long,
-                           val url: String? = null)
+data class SharedUiMessage(
+    val sender: String,
+    val message: String,
+    val id: String,
+    val timestamp: Long,
+    val url: String? = null
+)
 class MatrixChatRoom(private val msession: MatrixSession, val room_id: String, val name: String) : MatrixState() {
     val messages: List<SharedUiMessage> = msession.getRoomEvents(room_id).map {
         if (it as? RoomMessageEvent != null) {
-            if(it.content.url != null) {
-                when(val img_local = msession.getLocalImagePathFromUrl(it.content.url)) {
-                    is Success -> { SharedUiMessage(it.sender, it.content.body, it.event_id,
-                                                    it.origin_server_ts, img_local.value) }
+            if (it.content.url != null) {
+                when (val img_local = msession.getLocalImagePathFromUrl(it.content.url)) {
+                    is Success -> {
+                        SharedUiMessage(
+                            it.sender, it.content.body, it.event_id,
+                            it.origin_server_ts, img_local.value
+                        )
+                    }
                     is Error -> {
-                        SharedUiMessage(it.sender, "Failed to load image ${it.content.url}",
-                                        it.event_id, it.origin_server_ts)
+                        SharedUiMessage(
+                            it.sender, "Failed to load image ${it.content.url}",
+                            it.event_id, it.origin_server_ts
+                        )
                     }
                 }
             } else {

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
@@ -78,11 +78,23 @@ class MatrixRooms(private val msession: MatrixSession, val message: String) : Ma
         return MatrixLogin("Closing session, returning to the login prompt for now\n", MatrixClient())
     }
 }
-data class SharedUiMessage(val sender: String, val message: String, val id: String, val timestamp: Long)
+data class SharedUiMessage(val sender: String, val message: String, val id: String, val timestamp: Long,
+                           val url: String? = null)
 class MatrixChatRoom(private val msession: MatrixSession, val room_id: String, val name: String) : MatrixState() {
     val messages: List<SharedUiMessage> = msession.getRoomEvents(room_id).map {
         if (it as? RoomMessageEvent != null) {
-            SharedUiMessage(it.sender, it.content.body, it.event_id, it.origin_server_ts)
+            if(it.content.url != null) {
+                when(val img_local = msession.getLocalImagePathFromUrl(it.content.url)) {
+                    is Success -> { SharedUiMessage(it.sender, it.content.body, it.event_id,
+                                                    it.origin_server_ts, img_local.value) }
+                    is Error -> {
+                        SharedUiMessage(it.sender, "Failed to load image ${it.content.url}",
+                                        it.event_id, it.origin_server_ts)
+                    }
+                }
+            } else {
+                SharedUiMessage(it.sender, it.content.body, it.event_id, it.origin_server_ts)
+            }
         } else { null }
     }.filterNotNull()
     fun sendMessage(msg: String): MatrixState {

--- a/serif_shared/src/commonMain/sqldelight/xyz/room409/serif/serif_shared/db/SessionDb.sq
+++ b/serif_shared/src/commonMain/sqldelight/xyz/room409/serif/serif_shared/db/SessionDb.sq
@@ -23,3 +23,24 @@ SELECT * FROM SavedSessions;
 selectUserSession:
 SELECT * FROM SavedSessions
 WHERE userId = ?;
+
+CREATE TABLE IF NOT EXISTS MediaCache (
+ mxcUrl TEXT NOT NULL PRIMARY KEY,
+ localPath TEXT NOT NULL
+);
+
+insertMedia:
+INSERT INTO MediaCache(mxcUrl, localPath)
+VALUES(?,?);
+
+updateMedia:
+UPDATE MediaCache
+SET localPath = ?
+WHERE mxcUrl = ?;
+
+selectCachedMedia:
+SELECT * FROM MediaCache
+WHERE mxcUrl = ?;
+
+deleteAllCache:
+DELETE FROM MediaCache;

--- a/serif_swing/src/main/kotlin/serif_swing/App.kt
+++ b/serif_swing/src/main/kotlin/serif_swing/App.kt
@@ -150,20 +150,30 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
         val layout = inner_scroll_pane.layout as GroupLayout
         val parallel_group = layout.createParallelGroup(GroupLayout.Alignment.LEADING)
         var seq_vert_groups = layout.createSequentialGroup()
-        for ((sender, message) in m.messages) {
-            val sender = JLabel("$sender:  ")
+        for (msg in m.messages) {
+            val _sender = msg.sender
+            val message = msg.message
+            val url = msg.url
+            val sender = JLabel("$_sender:  ")
 
-            val message = JTextArea(message)
-            message.setEditable(false)
-            message.lineWrap = true
-            message.wrapStyleWord = true
-
+            val msg_widget =
+            if(url != null) {
+                val img = ImageIcon(url);
+                val label = JLabel(img)
+                label
+            } else {
+                val message = JTextArea(message)
+                message.setEditable(false)
+                message.lineWrap = true
+                message.wrapStyleWord = true
+                message
+            }
             parallel_group.addComponent(sender)
-            parallel_group.addComponent(message)
+            parallel_group.addComponent(msg_widget)
             seq_vert_groups.addComponent(sender)
             seq_vert_groups.addGroup(layout.createSequentialGroup()
-                            .addPreferredGap(sender, message, LayoutStyle.ComponentPlacement.INDENT)
-                            .addComponent(message))
+                            .addPreferredGap(sender, msg_widget, LayoutStyle.ComponentPlacement.INDENT)
+                            .addComponent(msg_widget))
 
         }
         layout.setHorizontalGroup(parallel_group)

--- a/serif_swing/src/main/kotlin/serif_swing/App.kt
+++ b/serif_swing/src/main/kotlin/serif_swing/App.kt
@@ -134,8 +134,6 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
 
         val group_layout = GroupLayout(inner_scroll_pane)
         inner_scroll_pane.layout = group_layout
-        group_layout.autoCreateGaps = true
-        group_layout.autoCreateContainerGaps = true
         redrawMessages()
         panel.add(
             JScrollPane(
@@ -183,7 +181,7 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
         back_button.addActionListener({ transition(m.exitRoom(), true) })
     }
     fun redrawMessages() {
-        val inner_scroll_pane_pref_dim = inner_scroll_pane.preferredSize
+        val isp_width = inner_scroll_pane.getWidth()
         inner_scroll_pane.removeAll()
         val layout = inner_scroll_pane.layout as GroupLayout
         val parallel_group = layout.createParallelGroup(GroupLayout.Alignment.LEADING)
@@ -196,13 +194,17 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
 
             val msg_widget =
                 if (url != null) {
-                    val og_image = ImageIcon(url).image
-                    val isp_width: Int = inner_scroll_pane_pref_dim.width
+                    val og_image_icon = ImageIcon(url)
+                    val og_image = og_image_icon.image
                     val img_width: Int = og_image.getWidth(null)
                     val img_height: Int = og_image.getHeight(null)
-                    val new_width = min(isp_width, img_width)
-                    val new_height = min(img_height, (img_height * new_width)/img_width)
-                    JLabel(ImageIcon(og_image.getScaledInstance(new_width, new_height, Image.SCALE_DEFAULT)))
+                    if (isp_width != 0 && img_width != 0 && img_height != 0) {
+                        val new_width = min(isp_width, img_width)
+                        val new_height = min(img_height, (img_height * new_width)/img_width)
+                        JLabel(ImageIcon(og_image.getScaledInstance(new_width, new_height, Image.SCALE_DEFAULT)))
+                    } else {
+                        JLabel(og_image_icon)
+                    }
                 } else {
                     val message = JTextArea(message)
                     message.setEditable(false)

--- a/serif_swing/src/main/kotlin/serif_swing/App.kt
+++ b/serif_swing/src/main/kotlin/serif_swing/App.kt
@@ -5,6 +5,7 @@ package xyz.room409.serif.serif_swing
 import com.formdev.flatlaf.*
 import xyz.room409.serif.serif_shared.*
 import xyz.room409.serif.serif_shared.db.DriverFactory
+import kotlin.math.min
 import java.awt.*
 import java.awt.event.*
 import javax.swing.*
@@ -182,6 +183,7 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
         back_button.addActionListener({ transition(m.exitRoom(), true) })
     }
     fun redrawMessages() {
+        val inner_scroll_pane_pref_dim = inner_scroll_pane.preferredSize
         inner_scroll_pane.removeAll()
         val layout = inner_scroll_pane.layout as GroupLayout
         val parallel_group = layout.createParallelGroup(GroupLayout.Alignment.LEADING)
@@ -194,9 +196,13 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
 
             val msg_widget =
                 if (url != null) {
-                    val img = ImageIcon(url)
-                    val label = JLabel(img)
-                    label
+                    val og_image = ImageIcon(url).image
+                    val isp_width: Int = inner_scroll_pane_pref_dim.width
+                    val img_width: Int = og_image.getWidth(null)
+                    val img_height: Int = og_image.getHeight(null)
+                    val new_width = min(isp_width, img_width)
+                    val new_height = min(img_height, (img_height * new_width)/img_width)
+                    JLabel(ImageIcon(og_image.getScaledInstance(new_width, new_height, Image.SCALE_DEFAULT)))
                 } else {
                     val message = JTextArea(message)
                     message.setEditable(false)

--- a/serif_swing/src/main/kotlin/serif_swing/App.kt
+++ b/serif_swing/src/main/kotlin/serif_swing/App.kt
@@ -120,7 +120,7 @@ class ImageFileFilter : FileFilter() {
         return "Supported Image files"
     }
 }
-class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: JPanel, var m: MatrixChatRoom) : SwingState() {
+class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: JPanel, var m: MatrixChatRoom, var last_window_width: Int) : SwingState() {
     var inner_scroll_pane = JPanel()
     var c_left = GridBagConstraints()
     var c_right = GridBagConstraints()
@@ -134,7 +134,7 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
 
         val group_layout = GroupLayout(inner_scroll_pane)
         inner_scroll_pane.layout = group_layout
-        redrawMessages()
+        redrawMessages(last_window_width)
         panel.add(
             JScrollPane(
                 inner_scroll_pane,
@@ -180,8 +180,7 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
         attach_button.addActionListener(onAttach)
         back_button.addActionListener({ transition(m.exitRoom(), true) })
     }
-    fun redrawMessages() {
-        val isp_width = inner_scroll_pane.getWidth()
+    fun redrawMessages(draw_width: Int) {
         inner_scroll_pane.removeAll()
         val layout = inner_scroll_pane.layout as GroupLayout
         val parallel_group = layout.createParallelGroup(GroupLayout.Alignment.LEADING)
@@ -190,7 +189,10 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
             val _sender = msg.sender
             val message = msg.message
             val url = msg.url
-            val sender = JLabel("$_sender:  ")
+            val sender = JTextArea("$_sender:  ")
+            sender.setEditable(false)
+            sender.lineWrap = true
+            sender.wrapStyleWord = true
 
             val msg_widget =
                 if (url != null) {
@@ -198,8 +200,8 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
                     val og_image = og_image_icon.image
                     val img_width: Int = og_image.getWidth(null)
                     val img_height: Int = og_image.getHeight(null)
-                    if (isp_width != 0 && img_width != 0 && img_height != 0) {
-                        val new_width = min(isp_width, img_width)
+                    if (draw_width != 0 && img_width != 0 && img_height != 0) {
+                        val new_width = min(draw_width, img_width)
                         val new_height = min(img_height, (img_height * new_width)/img_width)
                         JLabel(ImageIcon(og_image.getScaledInstance(new_width, new_height, Image.SCALE_DEFAULT)))
                     } else {
@@ -227,10 +229,11 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
     override fun refresh() {
         transition(m.refresh(), true)
     }
-    fun update(new_m: MatrixChatRoom) {
-        if (m.messages != new_m.messages) {
+    fun update(new_m: MatrixChatRoom, window_width: Int) {
+        if (m.messages != new_m.messages || last_window_width != window_width) {
             m = new_m
-            redrawMessages()
+            redrawMessages(window_width)
+            last_window_width = window_width
         } else {
             m = new_m
         }
@@ -258,7 +261,7 @@ class App {
         val s = sstate
         if (partial) {
             when {
-                new_state is MatrixChatRoom && s is SwingChatRoom -> { s.update(new_state); return; }
+                new_state is MatrixChatRoom && s is SwingChatRoom -> { s.update(new_state, frame.width); return; }
                 new_state is MatrixRooms && s is SwingRooms -> { s.update(new_state); return; }
             }
         }
@@ -267,21 +270,25 @@ class App {
 
     fun constructStateView(mstate: MatrixState): SwingState {
         frame.contentPane.removeAll()
+        val refresh_all = {
+            sstate.refresh()
+            frame.validate()
+            frame.repaint();
+        }
+        frame.addComponentListener(object : ComponentAdapter() {
+            override fun componentResized(e: ComponentEvent) {
+                refresh_all()
+            }
+        })
         var panel = JPanel()
         val to_ret = when (mstate) {
             is MatrixLogin -> SwingLogin(
                 ::transition,
-                {
-                    javax.swing.SwingUtilities.invokeLater({
-                        sstate.refresh()
-                        frame.validate()
-                        frame.repaint()
-                    })
-                },
+                { javax.swing.SwingUtilities.invokeLater(refresh_all) },
                 panel, mstate
             )
             is MatrixRooms -> SwingRooms(::transition, panel, mstate)
-            is MatrixChatRoom -> SwingChatRoom(::transition, panel, mstate)
+            is MatrixChatRoom -> SwingChatRoom(::transition, panel, mstate, frame.width)
         }
         frame.add(panel)
         frame.validate()

--- a/serif_swing/src/main/kotlin/serif_swing/App.kt
+++ b/serif_swing/src/main/kotlin/serif_swing/App.kt
@@ -72,7 +72,7 @@ class SwingRooms(val transition: (MatrixState, Boolean) -> Unit, val panel: JPan
         panel.layout = BorderLayout()
         panel.add(message_label, BorderLayout.PAGE_START)
 
-        inner_scroll_pane.layout = GridLayout(0,1)
+        inner_scroll_pane.layout = GridLayout(0, 1)
         for ((id, name, unreadCount, highlightCount, lastMessage) in m.rooms) {
             var button = JButton()
             button.layout = BoxLayout(button, BoxLayout.PAGE_AXIS)
@@ -122,10 +122,14 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
         group_layout.autoCreateGaps = true
         group_layout.autoCreateContainerGaps = true
         redrawMessages()
-        panel.add(JScrollPane(inner_scroll_pane,
-                              JScrollPane.VERTICAL_SCROLLBAR_ALWAYS,
-                              JScrollPane.HORIZONTAL_SCROLLBAR_NEVER),
-                  BorderLayout.CENTER)
+        panel.add(
+            JScrollPane(
+                inner_scroll_pane,
+                JScrollPane.VERTICAL_SCROLLBAR_ALWAYS,
+                JScrollPane.HORIZONTAL_SCROLLBAR_NEVER
+            ),
+            BorderLayout.CENTER
+        )
 
         val message_panel = JPanel()
         message_panel.layout = BorderLayout()
@@ -143,7 +147,6 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
         message_field.addActionListener(onSend)
         send_button.addActionListener(onSend)
         back_button.addActionListener({ transition(m.exitRoom(), true) })
-
     }
     fun redrawMessages() {
         inner_scroll_pane.removeAll()
@@ -157,24 +160,25 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
             val sender = JLabel("$_sender:  ")
 
             val msg_widget =
-            if(url != null) {
-                val img = ImageIcon(url);
-                val label = JLabel(img)
-                label
-            } else {
-                val message = JTextArea(message)
-                message.setEditable(false)
-                message.lineWrap = true
-                message.wrapStyleWord = true
-                message
-            }
+                if (url != null) {
+                    val img = ImageIcon(url)
+                    val label = JLabel(img)
+                    label
+                } else {
+                    val message = JTextArea(message)
+                    message.setEditable(false)
+                    message.lineWrap = true
+                    message.wrapStyleWord = true
+                    message
+                }
             parallel_group.addComponent(sender)
             parallel_group.addComponent(msg_widget)
             seq_vert_groups.addComponent(sender)
-            seq_vert_groups.addGroup(layout.createSequentialGroup()
-                            .addPreferredGap(sender, msg_widget, LayoutStyle.ComponentPlacement.INDENT)
-                            .addComponent(msg_widget))
-
+            seq_vert_groups.addGroup(
+                layout.createSequentialGroup()
+                    .addPreferredGap(sender, msg_widget, LayoutStyle.ComponentPlacement.INDENT)
+                    .addComponent(msg_widget)
+            )
         }
         layout.setHorizontalGroup(parallel_group)
         layout.setVerticalGroup(seq_vert_groups)
@@ -224,13 +228,17 @@ class App {
         frame.contentPane.removeAll()
         var panel = JPanel()
         val to_ret = when (mstate) {
-            is MatrixLogin -> SwingLogin(::transition, {
-                javax.swing.SwingUtilities.invokeLater({
-                    sstate.refresh()
-                    frame.validate()
-                    frame.repaint()
-                })
-            }, panel, mstate)
+            is MatrixLogin -> SwingLogin(
+                ::transition,
+                {
+                    javax.swing.SwingUtilities.invokeLater({
+                        sstate.refresh()
+                        frame.validate()
+                        frame.repaint()
+                    })
+                },
+                panel, mstate
+            )
             is MatrixRooms -> SwingRooms(::transition, panel, mstate)
             is MatrixChatRoom -> SwingChatRoom(::transition, panel, mstate)
         }
@@ -243,6 +251,6 @@ class App {
 
 fun main(args: Array<String>) {
     FlatDarkLaf.install()
-    UIManager.getLookAndFeelDefaults().put("defaultFont", Font("Serif", Font.PLAIN, 16));
+    UIManager.getLookAndFeelDefaults().put("defaultFont", Font("Serif", Font.PLAIN, 16))
     javax.swing.SwingUtilities.invokeLater({ App() })
 }


### PR DESCRIPTION
Fixes #28 #34 

Adds support for image events, displays the image inline in the chat room in the swing version of the app, and caches image downloads, maintaining a map of matrix url to local file path.