### PR TITLE
Edits and Replies support

### DIFF
--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Database.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Database.kt
@@ -47,9 +47,9 @@ object Database {
     }
 
     fun addMediaToCache(url: String, file_data: ByteArray, update: Boolean): String {
-        val cache_path = File(System.getProperty("user.dir") + "/cache/images/")
+        val cache_path = File(System.getProperty("user.dir") + "/cache/")
         cache_path.mkdirs()
-        val file = File.createTempFile("media_", "img", cache_path)
+        val file = File.createTempFile("serif_media_", "", cache_path)
         file.outputStream().write(file_data)
         val local = file.toPath().toString()
         if(update) {

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Events.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Events.kt
@@ -25,7 +25,7 @@ data class SendRoomMessage(
     @SerialName("m.relates_to") val replybock: RelationBlock? = null
 ) {
     constructor(body: String) : this(msgtype = "m.text", body = body)
-    constructor(body: String, rel_to: RelationBlock) : this(msgtype = "m.text", body = body, replybock = rel_to)
+    constructor(body: String, rel_to: RelationBlock?) : this(msgtype = "m.text", body = body, replybock = rel_to)
 }
 @Serializable
 data class AudioInfo(val duration: Int? = null, val size: Int, val mimetype: String)
@@ -171,8 +171,25 @@ class RoomEventFallback(
 class ReplyToRelation(val event_id: String)
 @Serializable
 class RelationBlock(
-@SerialName("m.in_reply_to") val in_reply_to: ReplyToRelation?
+@SerialName("m.in_reply_to") val in_reply_to: ReplyToRelation? = null,
+val rel_type: String? = null,
+val event_id: String? = null,
 )
+
+@Serializable
+class SendMessageEdit(
+    val body: String,
+    val msgtype: String,
+    @SerialName("m.new_content") val new_content: TextRMEC,
+    @SerialName("m.relates_to") val relates_to: RelationBlock
+) {
+    constructor(msg: String, fallback: String, original_event: String) : this(
+        body=fallback,
+        msgtype="m.text",
+        new_content=TextRMEC(msg,"m.text"),
+        relates_to=RelationBlock(null,"m.replace",original_event)
+    )
+}
 
 object EventSerializer : JsonContentPolymorphicSerializer<Event>(Event::class) {
     override fun selectDeserializer(element: JsonElement) = element.jsonObject["type"]!!.jsonPrimitive.content.let { type ->

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Events.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Events.kt
@@ -124,6 +124,7 @@ abstract class RoomMessageEventContent {
 class TextRMEC(
     override val body: String = "<missing message body, likely redacted>",
     override val msgtype: String = "<missing type, likely redacted>",
+    @SerialName("m.new_content") val new_content: TextRMEC? = null,
     @SerialName("m.relates_to") val relates_to: RelationBlock? = null
 ) : RoomMessageEventContent()
 @Serializable

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Events.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Events.kt
@@ -19,8 +19,13 @@ data class LoginIdentifier(val type: String, val user: String)
 data class LoginResponse(val access_token: String)
 
 @Serializable
-data class SendRoomMessage(val msgtype: String, val body: String) {
+data class SendRoomMessage(
+    val msgtype: String,
+    val body: String,
+    @SerialName("m.relates_to") val replybock: RelationBlock? = null
+) {
     constructor(body: String) : this(msgtype = "m.text", body = body)
+    constructor(body: String, rel_to: RelationBlock) : this(msgtype = "m.text", body = body, replybock = rel_to)
 }
 @Serializable
 data class AudioInfo(val duration: Int? = null, val size: Int, val mimetype: String)
@@ -119,6 +124,7 @@ abstract class RoomMessageEventContent {
 class TextRMEC(
     override val body: String = "<missing message body, likely redacted>",
     override val msgtype: String = "<missing type, likely redacted>",
+    @SerialName("m.relates_to") val relates_to: RelationBlock? = null
 ) : RoomMessageEventContent()
 @Serializable
 class ImageRMEC(
@@ -160,6 +166,13 @@ class RoomEventFallback(
 ) : RoomEvent() {
     override fun toString() = "RoomEventFallback(" + raw_self.toString() + ")"
 }
+
+@Serializable
+class ReplyToRelation(val event_id: String)
+@Serializable
+class RelationBlock(
+@SerialName("m.in_reply_to") val in_reply_to: ReplyToRelation?
+)
 
 object EventSerializer : JsonContentPolymorphicSerializer<Event>(Event::class) {
     override fun selectDeserializer(element: JsonElement) = element.jsonObject["type"]!!.jsonPrimitive.content.let { type ->

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Events.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Events.kt
@@ -16,7 +16,7 @@ data class LoginRequest(val type: String, val identifier: LoginIdentifier, val p
 data class LoginIdentifier(val type: String, val user: String)
 
 @Serializable
-data class LoginResponse(val access_token: String)
+data class LoginResponse(val access_token: String, val identifier: LoginIdentifier)
 
 @Serializable
 data class SendRoomMessage(

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Events.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Events.kt
@@ -22,11 +22,19 @@ data class LoginResponse(val access_token: String, val identifier: LoginIdentifi
 data class SendRoomMessage(
     val msgtype: String,
     val body: String,
-    @SerialName("m.relates_to") val replybock: RelationBlock? = null
+    @SerialName("m.new_content") val new_content: TextRMEC? = null,
+    @SerialName("m.relates_to") val relates_to: RelationBlock? = null
 ) {
     constructor(body: String) : this(msgtype = "m.text", body = body)
-    constructor(body: String, rel_to: RelationBlock?) : this(msgtype = "m.text", body = body, replybock = rel_to)
+    constructor(body: String, rel_to: RelationBlock?) : this(msgtype = "m.text", body = body, relates_to = rel_to)
+    constructor(msg: String, fallback: String, original_event: String) : this(
+        msgtype="m.text",
+        body=fallback,
+        new_content=TextRMEC(msg,"m.text"),
+        relates_to=RelationBlock(null,"m.replace",original_event)
+    )
 }
+
 @Serializable
 data class AudioInfo(val duration: Int? = null, val size: Int, val mimetype: String)
 @Serializable
@@ -176,21 +184,6 @@ class RelationBlock(
 val rel_type: String? = null,
 val event_id: String? = null,
 )
-
-@Serializable
-class SendMessageEdit(
-    val body: String,
-    val msgtype: String,
-    @SerialName("m.new_content") val new_content: TextRMEC,
-    @SerialName("m.relates_to") val relates_to: RelationBlock
-) {
-    constructor(msg: String, fallback: String, original_event: String) : this(
-        body=fallback,
-        msgtype="m.text",
-        new_content=TextRMEC(msg,"m.text"),
-        relates_to=RelationBlock(null,"m.replace",original_event)
-    )
-}
 
 object EventSerializer : JsonContentPolymorphicSerializer<Event>(Event::class) {
     override fun selectDeserializer(element: JsonElement) = element.jsonObject["type"]!!.jsonPrimitive.content.let { type ->

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/MatrixClient.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/MatrixClient.kt
@@ -98,7 +98,7 @@ class MatrixSession(val client: HttpClient, val user: String, val access_token: 
                 val message_confirmation =
                     client.put<EventIdResponse>("https://synapse.room409.xyz/_matrix/client/r0/rooms/$room_id/send/m.room.message/$transactionId?access_token=$access_token") {
                         contentType(ContentType.Application.Json)
-                        body = SendMessageEdit(msg, fallback_msg, edited_id)
+                        body = SendRoomMessage(msg, fallback_msg, edited_id)
                     }
                 transactionId++
                 Database.updateSession(access_token, transactionId)

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
@@ -83,7 +83,9 @@ open class SharedUiMessage(
     open val message: String,
     open val id: String,
     open val timestamp: Long,
-    open val replied_event: String = ""
+    open val replied_event: String = "",
+    open val edited_event: String = ""
+
 )
 class SharedUiImgMessage(
     override val sender: String,
@@ -121,7 +123,7 @@ class MatrixChatRoom(private val msession: MatrixSession, val room_id: String, v
                 }
             }
             when (msg_content) {
-                is TextRMEC -> SharedUiMessage(it.sender, it.content.body, it.event_id, it.origin_server_ts, msg_content.relates_to?.in_reply_to?.event_id)
+                is TextRMEC -> SharedUiMessage(it.sender, it.content.body, it.event_id, it.origin_server_ts, msg_content.relates_to?.in_reply_to?.event_id ?: "")
                 is ImageRMEC -> generate_media_msg(msg_content.url, ::SharedUiImgMessage)
                 is AudioRMEC -> generate_media_msg(msg_content.url, ::SharedUiAudioMessage)
                 else -> SharedUiMessage(it.sender, "UNHANDLED EVENT!!! ${it.content.body}", it.event_id, it.origin_server_ts)
@@ -143,8 +145,14 @@ class MatrixChatRoom(private val msession: MatrixSession, val room_id: String, v
         return this
     }
     fun sendReply(msg: String, replied: String): MatrixState {
-        val sendFunc = msession::sendMessage
-        when (val sendMessageResult = sendFunc(msg, room_id, replied)) {
+        when (val sendMessageResult = msession.sendMessage(msg, room_id, replied)) {
+            is Success -> { println("${sendMessageResult.value}") }
+            is Error -> { println("${sendMessageResult.message} - exception was ${sendMessageResult.cause}") }
+        }
+        return this
+    }
+    fun sendEdit(msg: String, edited_id: String): MatrixState {
+        when (val sendMessageResult = msession.sendEdit(msg, room_id, edited_id)) {
             is Success -> { println("${sendMessageResult.value}") }
             is Error -> { println("${sendMessageResult.message} - exception was ${sendMessageResult.cause}") }
         }

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
@@ -177,6 +177,21 @@ class MatrixChatRoom(private val msession: MatrixSession, val room_id: String, v
         }
         return this
     }
+    fun getEventSrc(msg_id: String): String {
+        for(event in msession.getRoomEvents(room_id)) {
+            if (event as? RoomMessageEvent != null) {
+                if(event.event_id == msg_id) {
+                    return event.raw_self.toString()
+                            .replace("\",","\",\n")
+                            .replace(",\"",",\n\"")
+                            .replace("{","{\n")
+                            .replace("}","\n}")
+                            .replace("\" \"","\"\n\"")
+                }
+            }
+        }
+        return "No Source for $msg_id"
+    }
     fun requestBackfill() {
         msession.requestBackfill(room_id)
     }

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
@@ -170,8 +170,7 @@ class MatrixChatRoom(private val msession: MatrixSession, val room_id: String, v
                                 "${edited.message} (edited)",
                                 edited.id,
                                 it.origin_server_ts,
-                                msg_content.relates_to?.in_reply_to?.event_id ?: "",
-                                it.event_id)
+                                msg_content.relates_to?.in_reply_to?.event_id ?: "")
                         } else {
                             //No edits for this event
                             SharedUiMessage(it.sender, it.content.body, it.event_id, it.origin_server_ts, msg_content.relates_to?.in_reply_to?.event_id ?: "")

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
@@ -103,6 +103,10 @@ class SharedUiAudioMessage(
 ) : SharedUiMessage(sender,message,id,timestamp)
 
 class MatrixChatRoom(private val msession: MatrixSession, val room_id: String, val name: String) : MatrixState() {
+    val username: String
+        get() {
+            return msession.user
+        }
     val edits: Map<String,SharedUiMessage> = msession.getRoomEvents(room_id).map {
         if (it as? RoomMessageEvent != null) {
             val msg_content = it.content

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
@@ -83,9 +83,7 @@ open class SharedUiMessage(
     open val message: String,
     open val id: String,
     open val timestamp: Long,
-    open val replied_event: String = "",
-    open val edited_event: String = ""
-
+    open val replied_event: String = ""
 )
 class SharedUiImgMessage(
     override val sender: String,
@@ -117,8 +115,7 @@ class MatrixChatRoom(private val msession: MatrixSession, val room_id: String, v
                         if(msg_content.relates_to?.event_id != null) {
                             val replaced_id = msg_content.relates_to.event_id
                             val edit_msg = SharedUiMessage(it.sender, msg_content.new_content.body,
-                                it.event_id, it.origin_server_ts, replied_event="",
-                                edited_event=replaced_id)
+                                it.event_id, it.origin_server_ts)
                             Pair(replaced_id,edit_msg)
                         } else {
                             //No idea which event this edit is editing 

--- a/serif_swing/src/main/kotlin/serif_swing/App.kt
+++ b/serif_swing/src/main/kotlin/serif_swing/App.kt
@@ -266,13 +266,7 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
                     play_btn
                 }
                 else -> {
-                    val message =
-                    if(m.edits.contains(msg.id)) {
-                        val edited = m.edits.get(msg.id)!!
-                        JTextArea("${edited.message} (edited)")
-                    } else {
-                        JTextArea("$message")
-                    }
+                    val message = JTextArea("$message")
                     message.setEditable(false)
                     message.lineWrap = true
                     message.wrapStyleWord = true
@@ -302,9 +296,6 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
                 val w = dim.width
                 val dialog = JDialog(window, "Event Source")
 
-                val top_panel = JPanel()
-                top_panel.layout = BoxLayout(top_panel, BoxLayout.LINE_AXIS)
-
                 val dpanel = JPanel(BorderLayout())
                 val src_txt = JTextPane()
                 src_txt.setContentType("text/plain")
@@ -319,8 +310,7 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
 
                 dpanel.add(JScrollPane(src_txt), BorderLayout.CENTER)
                 dpanel.add(close_btn,BorderLayout.PAGE_END)
-                top_panel.add(dpanel)
-                dialog.add(top_panel)
+                dialog.add(dpanel)
 
                 dialog.setSize(w,h/2)
                 dialog.setVisible(true)

--- a/serif_swing/src/main/kotlin/serif_swing/App.kt
+++ b/serif_swing/src/main/kotlin/serif_swing/App.kt
@@ -266,36 +266,51 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
                     play_btn
                 }
                 else -> {
-                    val message = JTextArea("$message")
+                    val message =
+                    if(m.edits.contains(msg.id)) {
+                        val edited = m.edits.get(msg.id)!!
+                        JTextArea("${edited.message} (edited)")
+                    } else {
+                        JTextArea("$message")
+                    }
                     message.setEditable(false)
                     message.lineWrap = true
                     message.wrapStyleWord = true
                     message
                 }
             }
-            val msg_reply_button = JButton("reply")
-            msg_reply_button.addActionListener({
+            val msg_action_popup = JPopupMenu()
+
+            val reply_option = JMenuItem("reply")
+            reply_option.addActionListener({
                 println("Now writing a reply")
                 replied_event_id = msg.id
             })
-            val msg_edit_button = JButton("edit")
-            msg_edit_button.addActionListener({
+            val edit_option = JMenuItem("edit")
+            edit_option.addActionListener({
                 println("Now editing a message")
                 edited_event_id = msg.id
                 message_field.text = msg.message
             })
+
+            msg_action_popup.add(reply_option)
+            if(show_edit_btn) msg_action_popup.add(edit_option)
+
+            val msg_action_button = JButton("...")
+            msg_action_button.addActionListener({
+                msg_action_popup.show(msg_action_button,0,0)
+            })
+
             parallel_group.addComponent(sender)
             parallel_group.addComponent(msg_widget)
-            parallel_group.addComponent(msg_reply_button)
-            if(show_edit_btn) parallel_group.addComponent(msg_edit_button)
+            parallel_group.addComponent(msg_action_button)
             seq_vert_groups.addComponent(sender)
             seq_vert_groups.addGroup(
                 layout.createSequentialGroup()
                     .addPreferredGap(sender, msg_widget, LayoutStyle.ComponentPlacement.INDENT)
                     .addComponent(msg_widget)
-                    .addComponent(msg_reply_button)
+                    .addComponent(msg_action_button)
             )
-            if(show_edit_btn) seq_vert_groups.addComponent(msg_edit_button)
         }
         layout.setHorizontalGroup(parallel_group)
         layout.setVerticalGroup(seq_vert_groups)

--- a/serif_swing/src/main/kotlin/serif_swing/App.kt
+++ b/serif_swing/src/main/kotlin/serif_swing/App.kt
@@ -281,20 +281,56 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
             }
             val msg_action_popup = JPopupMenu()
 
-            val reply_option = JMenuItem("reply")
+            val reply_option = JMenuItem("Reply")
             reply_option.addActionListener({
                 println("Now writing a reply")
                 replied_event_id = msg.id
             })
-            val edit_option = JMenuItem("edit")
+            val edit_option = JMenuItem("Edit")
             edit_option.addActionListener({
                 println("Now editing a message")
                 edited_event_id = msg.id
                 message_field.text = msg.message
             })
+            val show_src_option = JMenuItem("Show Source")
+            show_src_option.addActionListener({
+                val json_str = m.getEventSrc(msg.id)
+
+                val window = SwingUtilities.getWindowAncestor(panel)
+                val dim = window.getSize()
+                val h = dim.height
+                val w = dim.width
+                val dialog = JDialog(window, "Event Source")
+
+                val top_panel = JPanel()
+                top_panel.layout = BoxLayout(top_panel, BoxLayout.LINE_AXIS)
+
+                val dpanel = JPanel(BorderLayout())
+                val src_txt = JTextPane()
+                src_txt.setContentType("text/plain")
+                src_txt.setText(json_str)
+                src_txt.setEditable(false)
+
+                val close_btn = JButton("Close")
+                close_btn.addActionListener({
+                    dialog.setVisible(false)
+                    dialog.dispose()
+                })
+
+                dpanel.add(JScrollPane(src_txt), BorderLayout.CENTER)
+                dpanel.add(close_btn,BorderLayout.PAGE_END)
+                top_panel.add(dpanel)
+                dialog.add(top_panel)
+
+                dialog.setSize(w,h/2)
+                dialog.setVisible(true)
+                dialog.setResizable(false)
+                dialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE)
+            })
 
             msg_action_popup.add(reply_option)
             if(show_edit_btn) msg_action_popup.add(edit_option)
+            msg_action_popup.add(show_src_option)
 
             val msg_action_button = JButton("...")
             msg_action_button.addActionListener({


### PR DESCRIPTION
Fixes #43, #44, #61
Adds support for sending replies to messages and editing messages the user has sent in the swing gui.

Edits only work on text type messages right now, and some work should probably be done on better fallback messages for the replies, and both could be rendered better on the gui.

I would also eventually like to make replies have a clickable link portion that scrolls to the message it is relating to.