### PR TITLE
Video, file, and location content support

### DIFF
--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Events.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Events.kt
@@ -191,7 +191,7 @@ class FileRMEC(
     override val body: String = "<missing message body, likely redacted>",
     override val msgtype: String = "<missing type, likely redacted>",
     val info: FileInfo,
-    val filename: String,
+    val filename: String = "",
     val url: String
 ) : RoomMessageEventContent()
 @Serializable

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Events.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Events.kt
@@ -49,6 +49,10 @@ data class AudioInfo(val duration: Int? = null, val size: Int, val mimetype: Str
 @Serializable
 data class ImageInfo(val h: Int? = 0, val mimetype: String, val size: Int, val w: Int? = 0)
 @Serializable
+data class VideoInfo(val duration: Int? = 0, val mimetype: String, val size: Int, val h: Int? = 0, val w: Int? = 0)
+@Serializable
+data class FileInfo(val mimetype: String, val size: Int)
+@Serializable
 data class MediaUploadResponse(val content_uri: String)
 @Serializable
 data class EventIdResponse(val event_id: String)
@@ -176,6 +180,27 @@ class AudioRMEC(
     val url: String
 ) : RoomMessageEventContent()
 @Serializable
+class VideoRMEC(
+    override val body: String = "<missing message body, likely redacted>",
+    override val msgtype: String = "<missing type, likely redacted>",
+    val info: VideoInfo,
+    val url: String
+) : RoomMessageEventContent()
+@Serializable
+class FileRMEC(
+    override val body: String = "<missing message body, likely redacted>",
+    override val msgtype: String = "<missing type, likely redacted>",
+    val info: FileInfo,
+    val filename: String,
+    val url: String
+) : RoomMessageEventContent()
+@Serializable
+class LocationRMEC(
+    override val body: String = "<missing message body, likely redacted>",
+    override val msgtype: String = "<missing type, likely redacted>",
+    val geo_uri: String
+) : RoomMessageEventContent()
+@Serializable
 class FallbackRMEC(
     override val body: String = "<missing message body, likely redacted>",
     override val msgtype: String = "<missing type, likely redacted>",
@@ -231,6 +256,9 @@ object RoomMessageEventContentSerializer : JsonContentPolymorphicSerializer<Room
             type == "m.text" -> TextRMEC.serializer()
             type == "m.image" -> ImageRMEC.serializer()
             type == "m.audio" -> AudioRMEC.serializer()
+            type == "m.video" -> VideoRMEC.serializer()
+            type == "m.file" -> FileRMEC.serializer()
+            type == "m.location" -> LocationRMEC.serializer()
             else -> FallbackRMEC.serializer()
         }
     }

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
@@ -276,6 +276,7 @@ class MatrixChatRoom(private val msession: MatrixSession, val room_id: String, v
         }
         return "No Source for $msg_id"
     }
+    fun saveMediaToPath(path: String, url: String) = msession.saveMediaAtPathFromUrl(path,url)
     fun requestBackfill() {
         msession.requestBackfill(room_id)
     }

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
@@ -101,6 +101,31 @@ class SharedUiAudioMessage(
     override val timestamp: Long,
     val url: String
 ) : SharedUiMessage(sender, message, id, timestamp)
+class SharedUiVideoMessage(
+    override val sender: String,
+    override val message: String,
+    override val id: String,
+    override val timestamp: Long,
+    val url: String
+) : SharedUiMessage(sender, message, id, timestamp)
+class SharedUiFileMessage(
+    override val sender: String,
+    override val message: String,
+    override val id: String,
+    override val timestamp: Long,
+    val filename: String,
+    val mimetype: String,
+    val url: String
+) : SharedUiMessage(sender, message, id, timestamp)
+class SharedUiLocationMessage(
+    override val sender: String,
+    override val message: String,
+    override val id: String,
+    override val timestamp: Long,
+    val location: String
+) : SharedUiMessage(sender, message, id, timestamp)
+
+
 
 class MatrixChatRoom(private val msession: MatrixSession, val room_id: String, val name: String) : MatrixState() {
     val username = msession.user
@@ -190,6 +215,20 @@ class MatrixChatRoom(private val msession: MatrixSession, val room_id: String, v
                 }
                 is ImageRMEC -> generate_media_msg(msg_content.url, ::SharedUiImgMessage)
                 is AudioRMEC -> generate_media_msg(msg_content.url, ::SharedUiAudioMessage)
+                is VideoRMEC -> generate_media_msg(msg_content.url, ::SharedUiVideoMessage)
+                is FileRMEC -> {
+                    SharedUiFileMessage(
+                        it.sender, it.content.body, it.event_id,
+                        it.origin_server_ts, msg_content.filename,
+                        msg_content.info.mimetype, msg_content.url
+                    )
+                }
+                is LocationRMEC -> {
+                    SharedUiLocationMessage(
+                        it.sender, it.content.body, it.event_id,
+                        it.origin_server_ts, msg_content.geo_uri
+                    )
+                }
                 else -> SharedUiMessage(it.sender, "UNHANDLED EVENT!!! ${it.content.body}", it.event_id, it.origin_server_ts)
             }
         } else { null }

--- a/serif_swing/build.gradle.kts
+++ b/serif_swing/build.gradle.kts
@@ -34,6 +34,10 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit")
 
     implementation("com.formdev:flatlaf:1.0")
+
+    //video and audio codec support
+    implementation("org.jcodec:jcodec:0.2.5")
+    implementation("org.jcodec:jcodec-javase:0.2.5")
 }
 
 application {

--- a/serif_swing/src/main/kotlin/serif_swing/App.kt
+++ b/serif_swing/src/main/kotlin/serif_swing/App.kt
@@ -482,17 +482,31 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
                     }
                     is SharedUiFileMessage -> {
                         val file_url = msg.url
-                        val filename = msg.filename
+                        val filename = if(msg.filename != "") {
+                            msg.filename
+                        } else {
+                            msg.message
+                        }
                         val mimetype = msg.mimetype
                         val btn = JButton()
                         val message_panel = JPanel()
                         message_panel.layout = BoxLayout(message_panel, BoxLayout.PAGE_AXIS)
-                        val l = JLabel("Download $filename")
-                        message_panel.add(l)
-                        arrayOf(mimetype, file_url).forEach {
-                            message_panel.add(JLabel(it))
-                        }
+                        message_panel.add(JLabel("Download $filename"))
+                        message_panel.add(JLabel(mimetype))
                         btn.add(message_panel)
+                        btn.addActionListener({
+                            val chooser = JFileChooser()
+                            chooser.setSelectedFile(File(filename))
+                            val ret = chooser.showSaveDialog(btn)
+                            if(ret == JFileChooser.APPROVE_OPTION) {
+                                val user_file_path = chooser.getSelectedFile().getAbsolutePath()
+                                try {
+                                    m.saveMediaToPath(user_file_path, file_url)
+                                } catch (e: Exception) {
+                                    println("Couldn't save media, $e")
+                                }
+                            }
+                        })
                         btn
                     }
                     is SharedUiLocationMessage -> {

--- a/serif_swing/src/main/kotlin/serif_swing/App.kt
+++ b/serif_swing/src/main/kotlin/serif_swing/App.kt
@@ -82,6 +82,7 @@ class VideoPlayer {
             pic_out.setIcon(ImageIcon(image_array[idx]))
         }
     }
+    //Adapted from Jcodec https://github.com/jcodec/jcodec/blob/6e1ec651eca92d21b41f9790143a0e6e4d26811e/javase/src/main/java/org/jcodec/javase/scale/AWTUtil.java
     private fun toBufferedImage(_src: Picture): BufferedImage {
         var src = _src
 		if (src.getColor() != ColorSpace.BGR) {
@@ -106,6 +107,7 @@ class VideoPlayer {
 
         return dst
     }
+    //Adapted from Jcodec https://github.com/jcodec/jcodec/blob/6e1ec651eca92d21b41f9790143a0e6e4d26811e/javase/src/main/java/org/jcodec/javase/scale/AWTUtil.java
     private fun toBufferedImageCropped(src: Picture, dst: BufferedImage) {
         val data = (dst.getRaster().getDataBuffer() as DataBufferByte).getData();
         val srcData = src.getPlaneData(0);
@@ -128,6 +130,7 @@ class VideoPlayer {
             dstOff += dstStride;
         }
     }
+    //Adapted from Jcodec https://github.com/jcodec/jcodec/blob/6e1ec651eca92d21b41f9790143a0e6e4d26811e/javase/src/main/java/org/jcodec/javase/scale/AWTUtil.java
     private fun toBufferedImage(src: Picture, dst: BufferedImage) {
         val _data = (dst.getRaster().getDataBuffer() as DataBufferByte).getData();
         val srcData = src.getPlaneData(0);
@@ -465,7 +468,7 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
                         val message_panel = JPanel()
                         message_panel.layout = BoxLayout(message_panel, BoxLayout.PAGE_AXIS)
                         val video_url = msg.url
-                        val video_btn = JButton("Video $video_url")
+                        val video_btn = JButton()
                         val pic_chan = ImageIcon()
 
                         val vp = VideoPlayer()

--- a/serif_swing/src/main/kotlin/serif_swing/App.kt
+++ b/serif_swing/src/main/kotlin/serif_swing/App.kt
@@ -7,6 +7,8 @@ import xyz.room409.serif.serif_shared.*
 import xyz.room409.serif.serif_shared.db.DriverFactory
 import java.awt.*
 import java.awt.event.*
+import java.awt.image.BufferedImage
+import java.awt.image.DataBufferByte
 import java.io.BufferedReader
 import java.io.File
 import java.io.InputStreamReader
@@ -17,6 +19,17 @@ import javax.swing.text.*
 import javax.swing.text.html.HTML
 import kotlin.concurrent.thread
 import kotlin.math.min
+
+import java.util.Timer
+import kotlin.concurrent.fixedRateTimer
+import org.jcodec.common.io.NIOUtils
+import org.jcodec.api.FrameGrab
+import org.jcodec.common.model.Picture
+import org.jcodec.common.model.ColorSpace
+import org.jcodec.common.DemuxerTrack
+import org.jcodec.scale.ColorUtil
+import org.jcodec.scale.RgbToBgr
+import org.jcodec.scale.Transform
 
 object AudioPlayer {
     var url = ""
@@ -35,6 +48,114 @@ object AudioPlayer {
         }
         clip.setFramePosition(0)
         clip.start()
+    }
+}
+
+class VideoPlayer {
+    var url = ""
+    val image_array = ArrayList<BufferedImage>()
+    var playing_task = Timer()
+    var idx = 0
+    var framerate = 17L
+    var playing = false
+
+
+    fun loadVideo(video_url: String, pic_out: JButton) {
+        if (url != video_url) {
+            image_array.clear()
+            url = video_url
+            val file = File(video_url);
+            val grab = FrameGrab.createFrameGrab(NIOUtils.readableChannel(file))
+            val vt: DemuxerTrack = grab.getVideoTrack()
+            val frame_count = vt.getMeta().getTotalFrames()
+            val duration = vt.getMeta().getTotalDuration()
+            framerate = (1000.0*duration).toLong() / (frame_count).toLong()
+            while(true) {
+                val picture: Picture? = grab.getNativeFrame()
+                if(picture == null) {
+                    break
+                }
+                val buff_img = toBufferedImage(picture)
+                image_array.add(buff_img)
+            }
+            idx = 0
+            pic_out.setIcon(ImageIcon(image_array[idx]))
+        }
+    }
+    private fun toBufferedImage(_src: Picture): BufferedImage {
+        var src = _src
+		if (src.getColor() != ColorSpace.BGR) {
+			val bgr = Picture.createCropped(src.getWidth(), src.getHeight(), ColorSpace.BGR, src.getCrop())
+			if (src.getColor() == ColorSpace.RGB) {
+				RgbToBgr().transform(src, bgr)
+			} else {
+				val transform = ColorUtil.getTransform(src.getColor(), ColorSpace.RGB)
+				transform.transform(src, bgr)
+				RgbToBgr().transform(bgr, bgr)
+			}
+			src = bgr
+		}
+
+        var dst = BufferedImage(src.getCroppedWidth(), src.getCroppedHeight(),
+                BufferedImage.TYPE_3BYTE_BGR)
+
+        if (src.getCrop() == null)
+            toBufferedImage(src, dst);
+        else
+            toBufferedImageCropped(src, dst);
+
+        return dst
+    }
+    private fun toBufferedImageCropped(src: Picture, dst: BufferedImage) {
+        val data = (dst.getRaster().getDataBuffer() as DataBufferByte).getData();
+        val srcData = src.getPlaneData(0);
+        val dstStride = dst.getWidth() * 3;
+        val srcStride = src.getWidth() * 3;
+        var srcOff = 0
+        var dstOff = 0
+        for (line in  0..dst.getHeight()-1) {
+            var _is = srcOff
+            var id = dstOff
+            while (id < (dstOff + dstStride)) {
+                // Unshifting, since JCodec stores [0..255] -> [-128, 127]
+                data[id] = (srcData[_is] + 128).toByte()
+                data[id + 1] = (srcData[_is + 1] + 128).toByte()
+                data[id + 2] = (srcData[_is + 2] + 128).toByte()
+                id += 3
+                _is += 3
+            }
+            srcOff += srcStride;
+            dstOff += dstStride;
+        }
+    }
+    private fun toBufferedImage(src: Picture, dst: BufferedImage) {
+        val _data = (dst.getRaster().getDataBuffer() as DataBufferByte).getData();
+        val srcData = src.getPlaneData(0);
+        for (i in 0.._data.size-1) {
+            // Unshifting, since JCodec stores [0..255] -> [-128, 127]
+            _data[i] = (srcData[i] + 128).toByte()
+        }
+    }
+
+    private fun updateImage(pic_out: JButton) {
+        pic_out.setIcon(ImageIcon(image_array[idx]))
+        idx++
+    }
+    fun play(pic_out: JButton) {
+        if(playing) {
+            playing = false
+            playing_task.cancel()
+            println("Stopping video playback")
+        } else {
+            playing = true
+            println("Starting video playback")
+            playing_task = fixedRateTimer("pic cb", false, 0L, framerate) {
+                if(idx >= image_array.size) {
+                    idx = 0
+                }
+                updateImage(pic_out)
+            }
+        }
     }
 }
 
@@ -340,6 +461,56 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
                         })
                         play_btn
                     }
+                    is SharedUiVideoMessage -> {
+                        val message_panel = JPanel()
+                        message_panel.layout = BoxLayout(message_panel, BoxLayout.PAGE_AXIS)
+                        val video_url = msg.url
+                        val video_btn = JButton("Video $video_url")
+                        val pic_chan = ImageIcon()
+
+                        val vp = VideoPlayer()
+                        vp.loadVideo(video_url, video_btn)
+                        video_btn.addActionListener({
+                            vp.play(video_btn)
+                        })
+
+                        message_panel.add(video_btn)
+                        message_panel
+                    }
+                    is SharedUiFileMessage -> {
+                        val file_url = msg.url
+                        val filename = msg.filename
+                        val mimetype = msg.mimetype
+                        val btn = JButton()
+                        val message_panel = JPanel()
+                        message_panel.layout = BoxLayout(message_panel, BoxLayout.PAGE_AXIS)
+                        val l = JLabel("Download $filename")
+                        message_panel.add(l)
+                        arrayOf(mimetype, file_url).forEach {
+                            message_panel.add(JLabel(it))
+                        }
+                        btn.add(message_panel)
+                        btn
+                    }
+                    is SharedUiLocationMessage -> {
+                        val loc_str = msg.location
+                        val body = msg.message
+                        val btn = JButton()
+                        val message_panel = JPanel()
+                        message_panel.layout = BoxLayout(message_panel, BoxLayout.PAGE_AXIS)
+                        val l = JLabel("Location")
+                        message_panel.add(l)
+                        body.split("\n").forEach { part ->
+                            message_panel.add(JLabel(part))
+                        }
+                        btn.add(message_panel)
+                        val parts = loc_str.split(",")
+                        val lat = parts[0].replace("geo:","")
+                        val lon = parts[1]
+                        val href = "https://maps.google.com/?q=$lat,$lon"
+                        btn.addActionListener({ openUrl(href) })
+                        btn
+                    }
                     else -> {
                         val message = JTextPane()
                         message.setEditorKit(WrapEditorKit)
@@ -379,37 +550,7 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
                                         val el = doc.getCharacterElement(pos)
                                         val href = el.attributes.getAttribute(HTML.Attribute.HREF) as String?
                                         if (href != null) {
-                                            // In the background, so that GUI doesn't freeze
-                                            thread(start = true) {
-                                                // We have to try using xdg-open first,
-                                                // since PinePhone somehow implements the
-                                                // Desktop API but has the same problem with the
-                                                // GTK_BACKEND var
-                                                try {
-                                                    println("Trying to open $href with exec 'xdg-open $href'")
-                                                    val pb = ProcessBuilder("xdg-open", href)
-                                                    // Somehow this environment variable gets set for pb
-                                                    // when it's NOT in System.getenv(). And of course, this
-                                                    // is the one that makes xdg-open try to launch an X version
-                                                    // of Firefox, giving the dreaded Firefox is already running
-                                                    // message if you've got a Wayland version running already.
-                                                    pb.environment().clear()
-                                                    pb.environment().putAll(System.getenv())
-                                                    pb.redirectErrorStream(true)
-                                                    val process = pb.start()
-                                                    val reader = BufferedReader(InputStreamReader(process.inputStream))
-                                                    while (reader.readLine() != null) {}
-                                                    process.waitFor()
-                                                    println("done trying to open url")
-                                                } catch (e1: Exception) {
-                                                    try {
-                                                        println("Trying to open $href with Desktop")
-                                                        java.awt.Desktop.getDesktop().browse(java.net.URI(href))
-                                                    } catch (e2: Exception) {
-                                                        println("Couldn't get ProcessBuilder('xdg-open $href') or Desktop, problem was $e1 then $e2")
-                                                    }
-                                                }
-                                            }
+                                            openUrl(href)
                                         }
                                     }
                                 }
@@ -498,6 +639,39 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
             last_window_width = window_width
         } else {
             m = new_m
+        }
+    }
+    private fun openUrl(href: String) {
+        // In the background, so that GUI doesn't freeze
+        thread(start = true) {
+            // We have to try using xdg-open first,
+            // since PinePhone somehow implements the
+            // Desktop API but has the same problem with the
+            // GTK_BACKEND var
+            try {
+                println("Trying to open $href with exec 'xdg-open $href'")
+                val pb = ProcessBuilder("xdg-open", href)
+                // Somehow this environment variable gets set for pb
+                // when it's NOT in System.getenv(). And of course, this
+                // is the one that makes xdg-open try to launch an X version
+                // of Firefox, giving the dreaded Firefox is already running
+                // message if you've got a Wayland version running already.
+                pb.environment().clear()
+                pb.environment().putAll(System.getenv())
+                pb.redirectErrorStream(true)
+                val process = pb.start()
+                val reader = BufferedReader(InputStreamReader(process.inputStream))
+                while (reader.readLine() != null) {}
+                process.waitFor()
+                println("done trying to open url")
+            } catch (e1: Exception) {
+                try {
+                    println("Trying to open $href with Desktop")
+                    java.awt.Desktop.getDesktop().browse(java.net.URI(href))
+                } catch (e2: Exception) {
+                    println("Couldn't get ProcessBuilder('xdg-open $href') or Desktop, problem was $e1 then $e2")
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #31 #32 #40

Adds support for Video, File, and Location message types. Currently it only decodes visuals for the mp4 video messages. Will work on full video support on the swing gui later.