### PR TITLE
Event database

### DIFF
--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Database.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Database.kt
@@ -1,8 +1,13 @@
 package xyz.room409.serif.serif_shared
+
 import xyz.room409.serif.serif_shared.db.*
 import xyz.room409.serif.serif_shared.db.DriverFactory
 import xyz.room409.serif.serif_shared.db.SessionDb
+
 import java.io.File
+
+import kotlinx.serialization.*
+import kotlinx.serialization.json.*
 
 object Database {
     // See platform specific code in serif_shared for the
@@ -17,20 +22,27 @@ object Database {
         this.db?.sessionDbQueries?.insertSession(username, access_token, transactionId)
     }
 
-    fun updateSession(access_token: String, transactionId: Long) {
-        this.db?.sessionDbQueries?.updateSession(transactionId, access_token)
+    fun updateSessionTransactionId(access_token: String, transactionId: Long) {
+        this.db?.sessionDbQueries?.updateSessionTransactionId(transactionId, access_token)
     }
+
+    fun updateSessionNextBatch(access_token: String, nextBatch: String) {
+        this.db?.sessionDbQueries?.updateSessionNextBatch(nextBatch, access_token)
+    }
+    fun getSessionNextBatch(access_token: String): String? =
+
+        this.db?.sessionDbQueries?.getSessionNextBatch(access_token)?.executeAsOneOrNull()?.nextBatch
 
     fun getStoredSessions(): List<Triple<String, String, Long>> {
         val saved_sessions = this.db?.sessionDbQueries?.selectAllSessions(
-            { user: String, auth_tok: String, transactionId: Long ->
+            { user: String, auth_tok: String, nextBatch: String?, transactionId: Long ->
                 Triple(user, auth_tok, transactionId)
             })?.executeAsList() ?: listOf()
         return saved_sessions
     }
 
     fun getUserSession(user: String): Triple<String, String, Long> {
-        val saved_session = this.db?.sessionDbQueries?.selectUserSession(user) { user: String, auth_tok: String, transactionId: Long ->
+        val saved_session = this.db?.sessionDbQueries?.selectUserSession(user) { user: String, auth_tok: String, nextBatch: String?, transactionId: Long ->
             Triple(user, auth_tok, transactionId)
         }?.executeAsOne() ?: Triple("", "", 0L)
         return saved_session
@@ -59,4 +71,29 @@ object Database {
         }
         return local
     }
+
+    fun setStateEvent(roomId: String, event: StateEvent<*>) {
+        if (getStateEvent(roomId, event.type, event.state_key) != null) {
+            this.db?.sessionDbQueries?.updateStateEvent(event.raw_self.toString(), roomId, event.type, event.state_key)
+        } else {
+            this.db?.sessionDbQueries?.insertStateEvent(roomId, event.type, event.state_key, event.raw_self.toString())
+        }
+    }
+    fun getStateEvent(roomId: String, type: String, stateKey: String): String? =
+        this.db?.sessionDbQueries?.getStateEvent(roomId, type, stateKey)?.executeAsOneOrNull()
+    fun getStateEvents(roomId: String): List<Event> =
+        this.db?.sessionDbQueries?.getStateEvents(roomId)?.executeAsList()?.map { JsonFormatHolder.jsonFormat.decodeFromString<Event>(it) } ?: listOf()
+    fun getRooms(): List<String> =
+        this.db?.sessionDbQueries?.getRooms()?.executeAsList() ?: listOf()
+
+    fun getPrevBatch(roomId: String): String =
+        this.db!!.sessionDbQueries!!.getPrevBatch(roomId).executeAsOne().prevBatch!!
+
+    fun minId(): Long = this.db?.sessionDbQueries?.minId()?.executeAsOneOrNull()?.MIN ?: 0
+
+    fun addRoomEvent(seqId: Long?, roomId: String, event: RoomEvent, prevBatch: String?) {
+        this.db?.sessionDbQueries?.addRoomEvent(seqId, roomId, event.event_id, event.raw_self.toString(), prevBatch)
+    }
+    fun getRoomEvents(roomId: String): List<Event> =
+        this.db?.sessionDbQueries?.getRoomEvents(roomId)?.executeAsList()?.map { JsonFormatHolder.jsonFormat.decodeFromString<Event>(it) } ?: listOf()
 }

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Database.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Database.kt
@@ -116,9 +116,19 @@ object Database {
 
     fun minId(): Long = this.db?.sessionDbQueries?.minId()?.executeAsOneOrNull()?.MIN ?: 0
 
-    fun addRoomEvent(seqId: Long?, roomId: String, event: RoomEvent, prevBatch: String?) {
-        this.db?.sessionDbQueries?.addRoomEvent(seqId, roomId, event.event_id, event.raw_self.toString(), prevBatch)
+    fun addRoomEvent(seqId: Long?, roomId: String, event: RoomEvent, related_event: String?, prevBatch: String?) {
+        this.db?.sessionDbQueries?.addRoomEvent(seqId, roomId, event.event_id, event.raw_self.toString(), related_event, prevBatch)
     }
-    fun getRoomEvents(roomId: String): List<Event> =
-        this.db?.sessionDbQueries?.getRoomEvents(roomId)?.executeAsList()?.map { JsonFormatHolder.jsonFormat.decodeFromString<Event>(it) } ?: listOf()
+    fun getRoomEventAndIdx(roomId: String, eventId: String): Pair<Event, Long>? =
+        this.db?.sessionDbQueries?.getRoomEventAndIdx(roomId, eventId)?.executeAsOneOrNull()?.let {
+            Pair(JsonFormatHolder.jsonFormat.decodeFromString<Event>(it.data), it.seqId)
+        }
+    fun getRoomEventsBackwardsFromPoint(roomId: String, point: Long, number: Long): List<Pair<Event,Long>> =
+        this.db?.sessionDbQueries?.getRoomEventsBackwardsFromPointReversed(roomId, point, number)?.executeAsList()?.map { Pair(JsonFormatHolder.jsonFormat.decodeFromString<Event>(it.data), it.seqId) }?.reversed() ?: listOf()
+    fun getRoomEventsForwardsFromPoint(roomId: String, point: Long, number: Long): List<Pair<Event,Long>> =
+        this.db?.sessionDbQueries?.getRoomEventsForwardsFromPoint(roomId, point, number)?.executeAsList()?.map { Pair(JsonFormatHolder.jsonFormat.decodeFromString<Event>(it.data), it.seqId) } ?: listOf()
+    fun getMostRecentRoomEventAndIdx(roomId: String): Pair<Event,Long>? =
+        this.db?.sessionDbQueries?.getMostRecentRoomEvent(roomId)?.executeAsOneOrNull()?.let { Pair(JsonFormatHolder.jsonFormat.decodeFromString<Event>(it.data), it.seqId) }
+    fun getRelatedEvents(roomId: String, eventIds: List<String>): List<Pair<Event,Long>> =
+        this.db?.sessionDbQueries?.getRelatedEvents(roomId, eventIds)?.executeAsList()?.map { Pair(JsonFormatHolder.jsonFormat.decodeFromString<Event>(it.data), it.seqId) } ?: listOf()
 }

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Database.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Database.kt
@@ -22,28 +22,28 @@ object Database {
         this.db?.sessionDbQueries?.insertSession(username, access_token, transactionId)
     }
 
-    fun updateSessionTransactionId(access_token: String, transactionId: Long) {
-        this.db?.sessionDbQueries?.updateSessionTransactionId(transactionId, access_token)
+    fun updateSessionTransactionId(session_id: Long, transactionId: Long) {
+        this.db?.sessionDbQueries?.updateSessionTransactionId(transactionId, session_id)
     }
 
-    fun updateSessionNextBatch(access_token: String, nextBatch: String) {
-        this.db?.sessionDbQueries?.updateSessionNextBatch(nextBatch, access_token)
+    fun updateSessionNextBatch(session_id: Long, nextBatch: String) {
+        this.db?.sessionDbQueries?.updateSessionNextBatch(nextBatch, session_id)
     }
-    fun getSessionNextBatch(access_token: String): String? =
-        this.db?.sessionDbQueries?.getSessionNextBatch(access_token)?.executeAsOneOrNull()?.nextBatch
+    fun getSessionNextBatch(session_id: Long): String? =
+        this.db?.sessionDbQueries?.getSessionNextBatch(session_id)?.executeAsOneOrNull()?.nextBatch
 
     fun getStoredSessions(): List<Triple<String, String, Long>> {
         val saved_sessions = this.db?.sessionDbQueries?.selectAllSessions(
-            { user: String, auth_tok: String, nextBatch: String?, transactionId: Long ->
+            { id: Long, user: String, auth_tok: String, nextBatch: String?, transactionId: Long ->
                 Triple(user, auth_tok, transactionId)
             })?.executeAsList() ?: listOf()
         return saved_sessions
     }
 
-    fun getUserSession(user: String): Triple<String, String, Long> {
-        val saved_session = this.db?.sessionDbQueries?.selectUserSession(user) { user: String, auth_tok: String, nextBatch: String?, transactionId: Long ->
-            Triple(user, auth_tok, transactionId)
-        }?.executeAsOne() ?: Triple("", "", 0L)
+    fun getUserSession(user: String): Triple<String, Pair<Long, String>, Long> {
+        val saved_session = this.db?.sessionDbQueries?.selectUserSession(user) { id: Long, user: String, auth_tok: String, nextBatch: String?, transactionId: Long ->
+            Triple(user, Pair(id, auth_tok), transactionId)
+        }?.executeAsOne() ?: Triple("", Pair(0L,""), 0L)
         return saved_session
     }
 
@@ -71,23 +71,25 @@ object Database {
         return local
     }
 
-    fun <T> mapRooms(f: (String,String,Int,Int,RoomMessageEvent?) -> T): List<T> = (this.db?.sessionDbQueries?.getRooms()?.executeAsList() ?: listOf()).map { r ->
+    fun <T> mapRooms(session_id: Long, f: (String,String,Int,Int,RoomMessageEvent?) -> T): List<T> = (this.db?.sessionDbQueries?.getRooms(session_id)?.executeAsList() ?: listOf()).map { r ->
         f(r.id, r.name, r.unread_notif_count.toInt(), r.unread_highlight_count.toInt(), r.last_event?.let { JsonFormatHolder.jsonFormat.decodeFromString<Event>(it) as? RoomMessageEvent })
     }
 
     // setter that doesn't overwrite if passed null, if doesn't exist using default
-    fun setRoomSummary(id: String, name: String?, unread_notif_count: Int?, unread_highlight_count: Int?, last_event: RoomMessageEvent?) {
-        val old = this.db?.sessionDbQueries?.getRoom(id)?.executeAsOneOrNull()
+    fun setRoomSummary(session_id: Long, id: String, name: String?, unread_notif_count: Int?, unread_highlight_count: Int?, last_event: RoomMessageEvent?) {
+        val old = this.db?.sessionDbQueries?.getRoom(session_id, id)?.executeAsOneOrNull()
         if (old != null) {
             this.db?.sessionDbQueries?.updateRoomSummary(
                 name ?: old.name,
                 unread_notif_count?.toLong() ?: old?.unread_notif_count ?: 0,
                 unread_highlight_count?.toLong() ?: old?.unread_highlight_count ?: 0,
                 last_event?.raw_self?.toString() ?: old?.last_event,
+                session_id,
                 id
             )
         } else {
             this.db?.sessionDbQueries?.insertRoomSummary(
+                session_id,
                 id,
                 name ?: id,
                 unread_notif_count?.toLong() ?: 0,
@@ -96,41 +98,41 @@ object Database {
             )
         }
     }
-    fun getRoomName(id: String) = this.db?.sessionDbQueries?.getRoom(id)?.executeAsOneOrNull()?.name
+    fun getRoomName(session_id: Long, id: String) = this.db?.sessionDbQueries?.getRoom(session_id, id)?.executeAsOneOrNull()?.name
 
-    fun setStateEvent(roomId: String, event: StateEvent<*>) {
-        if (getStateEvent(roomId, event.type, event.state_key) != null) {
-            this.db?.sessionDbQueries?.updateStateEvent(event.raw_self.toString(), roomId, event.type, event.state_key)
+    fun setStateEvent(session_id: Long, roomId: String, event: StateEvent<*>) {
+        if (getStateEvent(session_id, roomId, event.type, event.state_key) != null) {
+            this.db?.sessionDbQueries?.updateStateEvent(event.raw_self.toString(), session_id, roomId, event.type, event.state_key)
         } else {
-            this.db?.sessionDbQueries?.insertStateEvent(roomId, event.type, event.state_key, event.raw_self.toString())
+            this.db?.sessionDbQueries?.insertStateEvent(session_id, roomId, event.type, event.state_key, event.raw_self.toString())
         }
     }
-    fun getStateEvent(roomId: String, type: String, stateKey: String): Event? =
-        this.db?.sessionDbQueries?.getStateEvent(roomId, type, stateKey)?.executeAsOneOrNull()?.let { JsonFormatHolder.jsonFormat.decodeFromString<Event>(it) }
-    fun getStateEvents(roomId: String): List<Event> =
-        this.db?.sessionDbQueries?.getStateEvents(roomId)?.executeAsList()?.map { JsonFormatHolder.jsonFormat.decodeFromString<Event>(it) } ?: listOf()
+    fun getStateEvent(session_id: Long, roomId: String, type: String, stateKey: String): Event? =
+        this.db?.sessionDbQueries?.getStateEvent(session_id, roomId, type, stateKey)?.executeAsOneOrNull()?.let { JsonFormatHolder.jsonFormat.decodeFromString<Event>(it) }
+    fun getStateEvents(session_id: Long, roomId: String): List<Event> =
+        this.db?.sessionDbQueries?.getStateEvents(session_id, roomId)?.executeAsList()?.map { JsonFormatHolder.jsonFormat.decodeFromString<Event>(it) } ?: listOf()
 
-    fun updatePrevBatch(roomId: String, eventId: String, prevBatch: String?) {
-        this.db!!.sessionDbQueries!!.updatePrevBatch(prevBatch, roomId, eventId)
+    fun updatePrevBatch(session_id: Long, roomId: String, eventId: String, prevBatch: String?) {
+        this.db!!.sessionDbQueries!!.updatePrevBatch(prevBatch, session_id, roomId, eventId)
     }
 
     fun minId(): String = this.db?.sessionDbQueries?.minId()?.executeAsOneOrNull()?.MIN ?: "z"
     fun maxId(): String = this.db?.sessionDbQueries?.maxId()?.executeAsOneOrNull()?.MAX ?: "a"
     fun maxIdLessThan(seqId: String): String = this.db?.sessionDbQueries?.maxIdLessThan(seqId)?.executeAsOneOrNull()?.MAX ?: "a"
 
-    fun addRoomEvent(seqId: String, roomId: String, event: RoomEvent, related_event: String?, prevBatch: String?) {
-        this.db?.sessionDbQueries?.addRoomEvent(seqId, roomId, event.event_id, event.raw_self.toString(), related_event, prevBatch)
+    fun addRoomEvent(seqId: String, sessionId: Long, roomId: String, event: RoomEvent, related_event: String?, prevBatch: String?) {
+        this.db?.sessionDbQueries?.addRoomEvent(seqId, sessionId, roomId, event.event_id, event.raw_self.toString(), related_event, prevBatch)
     }
-    fun getRoomEventAndIdx(roomId: String, eventId: String): Triple<RoomEvent, String, String?>? =
-        this.db?.sessionDbQueries?.getRoomEventAndIdx(roomId, eventId)?.executeAsOneOrNull()?.let {
+    fun getRoomEventAndIdx(session_id: Long, roomId: String, eventId: String): Triple<RoomEvent, String, String?>? =
+        this.db?.sessionDbQueries?.getRoomEventAndIdx(session_id, roomId, eventId)?.executeAsOneOrNull()?.let {
             Triple(JsonFormatHolder.jsonFormat.decodeFromString<Event>(it.data) as RoomEvent, it.seqId, it.prevBatch)
         }
-    fun getRoomEventsBackwardsFromPoint(roomId: String, point: String, number: Long): List<Triple<RoomEvent,String,String?>> =
-        this.db?.sessionDbQueries?.getRoomEventsBackwardsFromPointReversed(roomId, point, number)?.executeAsList()?.map { Triple(JsonFormatHolder.jsonFormat.decodeFromString<Event>(it.data) as RoomEvent, it.seqId, it.prevBatch) }?.reversed() ?: listOf()
-    fun getRoomEventsForwardsFromPoint(roomId: String, point: String, number: Long): List<Triple<RoomEvent,String,String?>> =
-        this.db?.sessionDbQueries?.getRoomEventsForwardsFromPoint(roomId, point, number)?.executeAsList()?.map { Triple(JsonFormatHolder.jsonFormat.decodeFromString<Event>(it.data) as RoomEvent, it.seqId, it.prevBatch) } ?: listOf()
-    fun getMostRecentRoomEventAndIdx(roomId: String): Triple<RoomEvent,String,String?>? =
-        this.db?.sessionDbQueries?.getMostRecentRoomEvent(roomId)?.executeAsOneOrNull()?.let { Triple(JsonFormatHolder.jsonFormat.decodeFromString<Event>(it.data) as RoomEvent, it.seqId, it.prevBatch) }
-    fun getRelatedEvents(roomId: String, eventIds: List<String>): List<Pair<RoomEvent,String>> =
-        this.db?.sessionDbQueries?.getRelatedEvents(roomId, eventIds)?.executeAsList()?.map { Pair(JsonFormatHolder.jsonFormat.decodeFromString<Event>(it.data) as RoomEvent, it.seqId) } ?: listOf()
+    fun getRoomEventsBackwardsFromPoint(session_id: Long, roomId: String, point: String, number: Long): List<Triple<RoomEvent,String,String?>> =
+        this.db?.sessionDbQueries?.getRoomEventsBackwardsFromPointReversed(session_id, roomId, point, number)?.executeAsList()?.map { Triple(JsonFormatHolder.jsonFormat.decodeFromString<Event>(it.data) as RoomEvent, it.seqId, it.prevBatch) }?.reversed() ?: listOf()
+    fun getRoomEventsForwardsFromPoint(session_id: Long, roomId: String, point: String, number: Long): List<Triple<RoomEvent,String,String?>> =
+        this.db?.sessionDbQueries?.getRoomEventsForwardsFromPoint(session_id, roomId, point, number)?.executeAsList()?.map { Triple(JsonFormatHolder.jsonFormat.decodeFromString<Event>(it.data) as RoomEvent, it.seqId, it.prevBatch) } ?: listOf()
+    fun getMostRecentRoomEventAndIdx(session_id: Long, roomId: String): Triple<RoomEvent,String,String?>? =
+        this.db?.sessionDbQueries?.getMostRecentRoomEvent(session_id, roomId)?.executeAsOneOrNull()?.let { Triple(JsonFormatHolder.jsonFormat.decodeFromString<Event>(it.data) as RoomEvent, it.seqId, it.prevBatch) }
+    fun getRelatedEvents(session_id: Long, roomId: String, eventIds: List<String>): List<Pair<RoomEvent,String>> =
+        this.db?.sessionDbQueries?.getRelatedEvents(session_id, roomId, eventIds)?.executeAsList()?.map { Pair(JsonFormatHolder.jsonFormat.decodeFromString<Event>(it.data) as RoomEvent, it.seqId) } ?: listOf()
 }

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Events.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Events.kt
@@ -72,7 +72,7 @@ data class Room(
     var unread_notifications: UnreadNotifications? = null
 )
 
-@Serializable data class Timeline(var events: List<Event>, var prev_batch: String)
+@Serializable data class Timeline(var events: List<Event>, var limited: Boolean = false, var prev_batch: String)
 
 @Serializable data class State(var events: List<Event>)
 

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
@@ -255,12 +255,23 @@ class MatrixChatRoom(private val msession: MatrixSession, val room_id: String, v
                         )
                     }
                     is ReactionRMEC -> null
-                    else -> SharedUiMessagePlain(it.sender, "UNHANDLED EVENT!!! ${it.content.body}", it.event_id, it.origin_server_ts, reactions)
+                    else -> SharedUiMessagePlain(it.sender, "UNHANDLED ROOM MESSAGE EVENT!!! ${it.content.body}", it.event_id, it.origin_server_ts, reactions)
                 }
-            } else { println("unhandled event $it"); null }
+            } else if (it as? RoomEvent != null) {
+                // This won't actually happen currently,
+                // as all non RoomMessageEvents will be filtered out by the
+                // isStandaloneEvent filter when pulling from the database.
+                // In general, keeping the two up to date will require
+                // some effort.
+                // TODO: something else? Either always show, or always hide?
+                println("unhandled room event $it")
+                SharedUiMessagePlain(it.sender, "UNHANDLED ROOM EVENT!!! $it", it.event_id, it.origin_server_ts, mapOf())
+            } else {
+                println("IMPOSSIBLE unhandled non room event $it")
+                throw Exception("IMPOSSIBLE unhandled non room event $it")
+                SharedUiMessagePlain("impossible", "impossible", "impossible", 0, mapOf())
+            }
         }.filterNotNull()
-        //messages = sl_messages.let { it.drop(max(0, it.size-(1+window_back_length+window_forward_length_in))) }
-        //println("Made messages for new chatroom, is ${messages.size} (sl${sl_messages.size}) long from ${event_range.size} returned from request for $window_back_length $message_window_base_in $window_forward_length_in")
         println("Made messages for new chatroom, is ${messages.size} (from ${event_range.size} returned from request for $window_back_length $message_window_base_in $window_forward_length_in")
     }
     val window_forward_length: Int = if (message_window_base != null) { window_forward_length_in } else { 0 }

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
@@ -50,16 +50,21 @@ fun determineRoomName(room: Room, id: String): String {
         ?: "<no room name - $id>"
 }
 class MatrixRooms(private val msession: MatrixSession, val message: String) : MatrixState() {
-    val rooms: List<SharedUiRoom> = msession.mapRooms { id, room ->
+    //val rooms: List<SharedUiRoom> = msession.mapRooms { id, state_events ->
+    val rooms: List<SharedUiRoom> = msession.mapRooms { id ->
         SharedUiRoom(
             id,
-            determineRoomName(room, id),
-            room.unread_notifications?.notification_count ?: 0,
-            room.unread_notifications?.highlight_count ?: 0,
-            room.timeline.events.findLast { it as? RoomMessageEvent != null }?.let {
-                val it = it as RoomMessageEvent
-                SharedUiMessagePlain(it.sender, it.content.body, it.event_id, it.origin_server_ts, mapOf())
-            }
+            id,
+            0,
+            0,
+            null
+            //determineRoomName(room, id),
+            //room.unread_notifications?.notification_count ?: 0,
+            //room.unread_notifications?.highlight_count ?: 0,
+            //room.timeline.events.findLast { it as? RoomMessageEvent != null }?.let {
+            //    val it = it as RoomMessageEvent
+            //    SharedUiMessagePlain(it.sender, it.content.body, it.event_id, it.origin_server_ts, mapOf())
+            //}
         )
     }.sortedBy { -(it.lastMessage?.timestamp ?: 0) }
     override fun refresh(): MatrixState = MatrixRooms(
@@ -354,7 +359,8 @@ class MatrixChatRoom(private val msession: MatrixSession, val room_id: String, v
     fun refresh(new_window_back_length: Int, new_message_window_base: String?, new_window_forward_length: Int): MatrixState = MatrixChatRoom(
         msession,
         room_id,
-        msession.mapRoom(room_id, { determineRoomName(it, room_id) }) ?: "<room gone?>",
+        room_id,
+        //msession.mapRoom(room_id, { determineRoomName(it, room_id) }) ?: "<room gone?>",
         new_window_back_length,
         new_message_window_base,
         new_window_forward_length,

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
@@ -43,28 +43,15 @@ class MatrixLogin(val login_message: String, val mclient: MatrixClient) : Matrix
     }
 }
 data class SharedUiRoom(val id: String, val name: String, val unreadCount: Int, val highlightCount: Int, val lastMessage: SharedUiMessage?)
-fun determineRoomName(room: Room, id: String): String {
-    return room.state.events.firstStateEventContentOfType<RoomNameContent>()?.name
-        ?: room.state.events.firstStateEventContentOfType<RoomCanonicalAliasContent>()?.alias
-        ?: room.summary.heroes?.joinToString(", ")
-        ?: "<no room name - $id>"
-}
 class MatrixRooms(private val msession: MatrixSession, val message: String) : MatrixState() {
     //val rooms: List<SharedUiRoom> = msession.mapRooms { id, state_events ->
-    val rooms: List<SharedUiRoom> = msession.mapRooms { id ->
+    val rooms: List<SharedUiRoom> = msession.mapRooms { id, name, unread_notif, unread_highlight, last_event ->
         SharedUiRoom(
             id,
-            id,
-            0,
-            0,
-            null
-            //determineRoomName(room, id),
-            //room.unread_notifications?.notification_count ?: 0,
-            //room.unread_notifications?.highlight_count ?: 0,
-            //room.timeline.events.findLast { it as? RoomMessageEvent != null }?.let {
-            //    val it = it as RoomMessageEvent
-            //    SharedUiMessagePlain(it.sender, it.content.body, it.event_id, it.origin_server_ts, mapOf())
-            //}
+            name,
+            unread_notif,
+            unread_highlight,
+            last_event?.let { SharedUiMessagePlain(it.sender, it.content.body, it.event_id, it.origin_server_ts, mapOf()) }
         )
     }.sortedBy { -(it.lastMessage?.timestamp ?: 0) }
     override fun refresh(): MatrixState = MatrixRooms(

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
@@ -272,7 +272,6 @@ class MatrixChatRoom(private val msession: MatrixSession, val room_id: String, v
                 SharedUiMessagePlain("impossible", "impossible", "impossible", 0, mapOf())
             }
         }.filterNotNull()
-        println("Made messages for new chatroom, is ${messages.size} (from ${event_range.size} returned from request for $window_back_length $message_window_base_in $window_forward_length_in")
     }
     val window_forward_length: Int = if (message_window_base != null) { window_forward_length_in } else { 0 }
     fun sendMessage(msg: String): MatrixState {
@@ -335,8 +334,7 @@ class MatrixChatRoom(private val msession: MatrixSession, val room_id: String, v
     fun refresh(new_window_back_length: Int, new_message_window_base: String?, new_window_forward_length: Int): MatrixState = MatrixChatRoom(
         msession,
         room_id,
-        room_id,
-        //msession.mapRoom(room_id, { determineRoomName(it, room_id) }) ?: "<room gone?>",
+        msession.getRoomName(room_id) ?: room_id,
         new_window_back_length,
         new_message_window_base,
         new_window_forward_length,

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
@@ -1,5 +1,6 @@
 package xyz.room409.serif.serif_shared
 import kotlin.collections.*
+import kotlin.math.*
 
 sealed class MatrixState {
     val version: String
@@ -44,7 +45,6 @@ class MatrixLogin(val login_message: String, val mclient: MatrixClient) : Matrix
 }
 data class SharedUiRoom(val id: String, val name: String, val unreadCount: Int, val highlightCount: Int, val lastMessage: SharedUiMessage?)
 class MatrixRooms(private val msession: MatrixSession, val message: String) : MatrixState() {
-    //val rooms: List<SharedUiRoom> = msession.mapRooms { id, state_events ->
     val rooms: List<SharedUiRoom> = msession.mapRooms { id, name, unread_notif, unread_highlight, last_event ->
         SharedUiRoom(
             id,
@@ -140,32 +140,31 @@ class SharedUiLocationMessage(
 ) : SharedUiMessage()
 
 
-class MatrixChatRoom(private val msession: MatrixSession, val room_id: String, val name: String, window_back_length_in: Int, message_window_base_in: String?, window_forward_length_in: Int) : MatrixState() {
+class MatrixChatRoom(private val msession: MatrixSession, val room_id: String, val name: String, val window_back_length: Int, message_window_base_in: String?, window_forward_length_in: Int) : MatrixState() {
     val username = msession.user
 
-    private val is_edit_content = { msg_content: TextRMEC ->
-        ((msg_content.new_content != null) && (msg_content.relates_to?.event_id != null))
-    }
     val messages: List<SharedUiMessage>
     val message_window_base: String?
     init {
         val edit_maps: MutableMap<String,ArrayList<SharedUiMessage>> = mutableMapOf()
         val reaction_maps: MutableMap<String, MutableMap<String, MutableSet<String>>> = mutableMapOf()
-        msession.getRoomEvents(room_id).forEach {
+
+        val (event_range, tracking_live) = msession.getReleventRoomEventsForWindow(room_id, window_back_length, message_window_base_in, window_forward_length_in)
+        if (tracking_live) {
+            message_window_base = null
+        } else {
+            message_window_base = message_window_base_in
+        }
+
+        event_range.forEach {
             if (it as? RoomMessageEvent != null) {
                 val msg_content = it.content
                 if (msg_content is ReactionRMEC) {
                     val relates_to = msg_content!!.relates_to!!.event_id!!
                     val key = msg_content!!.relates_to!!.key!!
                     val reactions_for_msg = reaction_maps.getOrPut(relates_to, { mutableMapOf() })
-                    val current_set = reactions_for_msg.getOrPut(key, { mutableSetOf() }).add(it.sender)
-                }
-            }
-        }
-        msession.getRoomEvents(room_id).forEach {
-            if (it as? RoomMessageEvent != null) {
-                val msg_content = it.content
-                if (msg_content is TextRMEC) {
+                    reactions_for_msg.getOrPut(key, { mutableSetOf() }).add(it.sender)
+                } else if (msg_content is TextRMEC) {
                     if (is_edit_content(msg_content)) {
                         // This is an edit
                         val replaced_id = msg_content!!.relates_to!!.event_id!!
@@ -183,7 +182,7 @@ class MatrixChatRoom(private val msession: MatrixSession, val room_id: String, v
             }
         }
         val edits: Map<String,ArrayList<SharedUiMessage>> = edit_maps.toMap()
-        messages = msession.getRoomEvents(room_id).map {
+        messages = event_range.map {
             if (it as? RoomMessageEvent != null) {
                 val reactions = reaction_maps.get(it.event_id)?.entries?.map { (key, senders) -> Pair(key, senders?.toSet() ?: setOf())}?.toMap() ?: mapOf()
                 val msg_content = it.content
@@ -259,31 +258,11 @@ class MatrixChatRoom(private val msession: MatrixSession, val room_id: String, v
                     else -> SharedUiMessagePlain(it.sender, "UNHANDLED EVENT!!! ${it.content.body}", it.event_id, it.origin_server_ts, reactions)
                 }
             } else { println("unhandled event $it"); null }
-        }.filterNotNull().let { all_messages ->
-            val base_idx = if (message_window_base_in == null) {
-                all_messages.size - 1
-            } else {
-                all_messages.indexOfFirst({ it.id == message_window_base_in })
-            }
-            val desired_first_index = base_idx - window_back_length_in
-            val first_index = if (desired_first_index < 0) {
-                println("Backfilling from States becuase $desired_first_index is < 0")
-                msession.requestBackfill(room_id)
-                0
-            } else {
-                desired_first_index
-            }
-            // we don't have a forward-fill yet, and indeed can't get ourselves into that position (yet)
-            val last_index = kotlin.math.min(all_messages.size - 1, base_idx + window_forward_length_in)
-            if (last_index == all_messages.size - 1) {
-                message_window_base = null
-            } else {
-                message_window_base = message_window_base_in
-            }
-            all_messages.slice(first_index .. last_index)
-        }
+        }.filterNotNull()
+        //messages = sl_messages.let { it.drop(max(0, it.size-(1+window_back_length+window_forward_length_in))) }
+        //println("Made messages for new chatroom, is ${messages.size} (sl${sl_messages.size}) long from ${event_range.size} returned from request for $window_back_length $message_window_base_in $window_forward_length_in")
+        println("Made messages for new chatroom, is ${messages.size} (from ${event_range.size} returned from request for $window_back_length $message_window_base_in $window_forward_length_in")
     }
-    val window_back_length: Int = window_back_length_in
     val window_forward_length: Int = if (message_window_base != null) { window_forward_length_in } else { 0 }
     fun sendMessage(msg: String): MatrixState {
         when (val sendMessageResult = msession.sendMessage(msg, room_id)) {
@@ -321,16 +300,15 @@ class MatrixChatRoom(private val msession: MatrixSession, val room_id: String, v
         return this
     }
     fun getEventSrc(msg_id: String): String {
-        for (event in msession.getRoomEvents(room_id)) {
-            if (event as? RoomMessageEvent != null) {
-                if (event.event_id == msg_id) {
-                    return event.raw_self.toString()
-                        .replace("\",", "\",\n")
-                        .replace(",\"", ",\n\"")
-                        .replace("{", "{\n")
-                        .replace("}", "\n}")
-                        .replace("\" \"", "\"\n\"")
-                }
+        val event = msession.getRoomEvent(room_id, msg_id)
+        if (event as? RoomMessageEvent != null) {
+            if (event.event_id == msg_id) {
+                return event.raw_self.toString()
+                    .replace("\",", "\",\n")
+                    .replace(",\"", ",\n\"")
+                    .replace("{", "{\n")
+                    .replace("}", "\n}")
+                    .replace("\" \"", "\"\n\"")
             }
         }
         return "No Source for $msg_id"

--- a/serif_shared/src/commonMain/sqldelight/xyz/room409/serif/serif_shared/db/SessionDb.sq
+++ b/serif_shared/src/commonMain/sqldelight/xyz/room409/serif/serif_shared/db/SessionDb.sq
@@ -112,7 +112,7 @@ WHERE (roomId = ?);
 
 
 CREATE TABLE IF NOT EXISTS RoomEvents (
- seqId INTEGER PRIMARY KEY NOT NULL,
+ seqId TEXT PRIMARY KEY NOT NULL,
  roomId TEXT NOT NULL,
  eventId TEXT NOT NULL,
  data TEXT NOT NULL,
@@ -125,29 +125,41 @@ CREATE INDEX IF NOT EXISTS RelatedEventIndex ON RoomEvents (relatedEvent);
 minId:
 SELECT MIN(seqId) FROM RoomEvents;
 
+maxId:
+SELECT MAX(seqId) FROM RoomEvents;
+
+maxIdLessThan:
+SELECT MAX(seqId) FROM RoomEvents
+WHERE (seqId < ?);
+
 addRoomEvent:
 INSERT INTO RoomEvents(seqId, roomId, eventId, data, relatedEvent, prevBatch)
 VALUES(?,?,?,?,?,?);
 
+updatePrevBatch:
+UPDATE RoomEvents
+SET prevBatch = ?
+WHERE (roomId = ? AND eventId = ?);
+
 getRoomEventAndIdx:
-SELECT data,seqId FROM RoomEvents
+SELECT data,seqId,prevBatch FROM RoomEvents
 WHERE (roomId = ? AND eventId = ?)
 LIMIT 1;
 
 getRoomEventsBackwardsFromPointReversed:
-SELECT data,seqId FROM RoomEvents
+SELECT data,seqId,prevBatch FROM RoomEvents
 WHERE (roomId = ?) AND (seqId < ?)
 ORDER BY seqId DESC
 LIMIT ?;
 
 getRoomEventsForwardsFromPoint:
-SELECT data,seqId FROM RoomEvents
+SELECT data,seqId,prevBatch FROM RoomEvents
 WHERE (roomId = ?) AND (seqId > ?)
 ORDER BY seqId ASC
 LIMIT ?;
 
 getMostRecentRoomEvent:
-SELECT data,seqId FROM RoomEvents
+SELECT data,seqId,prevBatch FROM RoomEvents
 WHERE (roomId = ?)
 ORDER BY seqId DESC
 LIMIT 1;
@@ -155,9 +167,3 @@ LIMIT 1;
 getRelatedEvents:
 SELECT data,seqId FROM RoomEvents
 WHERE (roomId = ?) AND (relatedEvent IN ?);
-
-getPrevBatch:
-SELECT prevBatch FROM RoomEvents
-WHERE (roomId = ? AND prevBatch IS NOT NULL)
-ORDER BY seqId ASC
-LIMIT 1;

--- a/serif_shared/src/commonMain/sqldelight/xyz/room409/serif/serif_shared/db/SessionDb.sq
+++ b/serif_shared/src/commonMain/sqldelight/xyz/room409/serif/serif_shared/db/SessionDb.sq
@@ -1,6 +1,7 @@
 CREATE TABLE IF NOT EXISTS SavedSessions (
  userId TEXT NOT NULL PRIMARY KEY,
  authTok TEXT NOT NULL,
+ nextBatch TEXT,
  transactionId INTEGER NOT NULL
 );
 
@@ -8,13 +9,22 @@ deleteAllSessions:
 DELETE FROM SavedSessions;
 
 insertSession:
-INSERT INTO SavedSessions(userId, authTok, transactionId)
-VALUES(?,?,?);
+INSERT INTO SavedSessions(userId, authTok, nextBatch, transactionId)
+VALUES(?,?,NULL,?);
 
-updateSession:
+updateSessionTransactionId:
 UPDATE SavedSessions
 SET transactionId = ?
 WHERE authTok = ?;
+
+updateSessionNextBatch:
+UPDATE SavedSessions
+SET nextBatch = ?
+WHERE authTok = ?;
+
+getSessionNextBatch:
+SELECT nextBatch FROM SavedSessions
+WHERE (authTok = ?);
 
 
 selectAllSessions:
@@ -44,3 +54,61 @@ WHERE mxcUrl = ?;
 
 deleteAllCache:
 DELETE FROM MediaCache;
+
+
+
+CREATE TABLE IF NOT EXISTS RoomState (
+ roomId TEXT NOT NULL,
+ type TEXT NOT NULL,
+ stateKey TEXT NOT NULL,
+ data TEXT NOT NULL,
+ PRIMARY KEY (roomId, type, stateKey)
+);
+
+insertStateEvent:
+INSERT INTO RoomState(roomId, type, stateKey, data)
+VALUES(?,?,?,?);
+
+updateStateEvent:
+UPDATE RoomState
+SET data = ?
+WHERE (roomId = ? AND type = ? AND stateKey = ?);
+
+getStateEvent:
+SELECT data FROM RoomState
+WHERE (roomId = ? AND type = ? AND stateKey = ?);
+
+getStateEvents:
+SELECT data FROM RoomState
+WHERE (roomId = ?);
+
+getRooms:
+SELECT DISTINCT roomId FROM RoomState;
+
+
+CREATE TABLE IF NOT EXISTS RoomEvents (
+ seqId INTEGER PRIMARY KEY NOT NULL,
+ roomId TEXT NOT NULL,
+ eventId TEXT NOT NULL,
+ data TEXT NOT NULL,
+ prevBatch TEXT
+);
+CREATE UNIQUE INDEX IF NOT EXISTS RoomEventIndex ON RoomEvents (roomId, eventId);
+
+minId:
+SELECT MIN(seqId) FROM RoomEvents;
+
+addRoomEvent:
+INSERT INTO RoomEvents(seqId, roomId, eventId, data, prevBatch)
+VALUES(?,?,?,?,?);
+
+getRoomEvents:
+SELECT data FROM RoomEvents
+WHERE (roomId = ?)
+ORDER BY seqId ASC;
+
+getPrevBatch:
+SELECT prevBatch FROM RoomEvents
+WHERE (roomId = ? AND prevBatch IS NOT NULL)
+ORDER BY seqId ASC
+LIMIT 1;

--- a/serif_shared/src/commonMain/sqldelight/xyz/room409/serif/serif_shared/db/SessionDb.sq
+++ b/serif_shared/src/commonMain/sqldelight/xyz/room409/serif/serif_shared/db/SessionDb.sq
@@ -116,21 +116,45 @@ CREATE TABLE IF NOT EXISTS RoomEvents (
  roomId TEXT NOT NULL,
  eventId TEXT NOT NULL,
  data TEXT NOT NULL,
+ relatedEvent TEXT,
  prevBatch TEXT
 );
 CREATE UNIQUE INDEX IF NOT EXISTS RoomEventIndex ON RoomEvents (roomId, eventId);
+CREATE UNIQUE INDEX IF NOT EXISTS RelatedEventIndex ON RoomEvents (relatedEvent);
 
 minId:
 SELECT MIN(seqId) FROM RoomEvents;
 
 addRoomEvent:
-INSERT INTO RoomEvents(seqId, roomId, eventId, data, prevBatch)
-VALUES(?,?,?,?,?);
+INSERT INTO RoomEvents(seqId, roomId, eventId, data, relatedEvent, prevBatch)
+VALUES(?,?,?,?,?,?);
 
-getRoomEvents:
-SELECT data FROM RoomEvents
+getRoomEventAndIdx:
+SELECT data,seqId FROM RoomEvents
+WHERE (roomId = ? AND eventId = ?)
+LIMIT 1;
+
+getRoomEventsBackwardsFromPointReversed:
+SELECT data,seqId FROM RoomEvents
+WHERE (roomId = ?) AND (seqId < ?)
+ORDER BY seqId DESC
+LIMIT ?;
+
+getRoomEventsForwardsFromPoint:
+SELECT data,seqId FROM RoomEvents
+WHERE (roomId = ?) AND (seqId > ?)
+ORDER BY seqId ASC
+LIMIT ?;
+
+getMostRecentRoomEvent:
+SELECT data,seqId FROM RoomEvents
 WHERE (roomId = ?)
-ORDER BY seqId ASC;
+ORDER BY seqId DESC
+LIMIT 1;
+
+getRelatedEvents:
+SELECT data,seqId FROM RoomEvents
+WHERE (roomId = ?) AND (relatedEvent IN ?);
 
 getPrevBatch:
 SELECT prevBatch FROM RoomEvents

--- a/serif_shared/src/commonMain/sqldelight/xyz/room409/serif/serif_shared/db/SessionDb.sq
+++ b/serif_shared/src/commonMain/sqldelight/xyz/room409/serif/serif_shared/db/SessionDb.sq
@@ -1,5 +1,6 @@
 CREATE TABLE IF NOT EXISTS SavedSessions (
- userId TEXT NOT NULL PRIMARY KEY,
+ id INTEGER PRIMARY KEY NOT NULL,
+ userId TEXT NOT NULL UNIQUE,
  authTok TEXT NOT NULL,
  nextBatch TEXT,
  transactionId INTEGER NOT NULL
@@ -9,22 +10,22 @@ deleteAllSessions:
 DELETE FROM SavedSessions;
 
 insertSession:
-INSERT INTO SavedSessions(userId, authTok, nextBatch, transactionId)
-VALUES(?,?,NULL,?);
+INSERT INTO SavedSessions(id, userId, authTok, nextBatch, transactionId)
+VALUES(NULL,?,?,NULL,?);
 
 updateSessionTransactionId:
 UPDATE SavedSessions
 SET transactionId = ?
-WHERE authTok = ?;
+WHERE id = ?;
 
 updateSessionNextBatch:
 UPDATE SavedSessions
 SET nextBatch = ?
-WHERE authTok = ?;
+WHERE id = ?;
 
 getSessionNextBatch:
 SELECT nextBatch FROM SavedSessions
-WHERE (authTok = ?);
+WHERE (id = ?);
 
 
 selectAllSessions:
@@ -58,69 +59,74 @@ DELETE FROM MediaCache;
 
 
 CREATE TABLE IF NOT EXISTS RoomSummary (
-    id TEXT PRIMARY KEY NOT NULL,
+    sessionId INTEGER NOT NULL,
+    id TEXT NOT NULL,
     name TEXT NOT NULL,
     unread_notif_count INTEGER NOT NULL,
     unread_highlight_count INTEGER NOT NULL,
-    last_event TEXT
+    last_event TEXT,
+    PRIMARY KEY (sessionId, id)
 );
 
 getRooms:
-SELECT * FROM RoomSummary;
+SELECT * FROM RoomSummary
+WHERE (sessionId = ? );
 
 getRoom:
 SELECT * FROM RoomSummary
-WHERE (id = ? )
+WHERE (sessionId = ? AND id = ? )
 LIMIT 1;
 
 insertRoomSummary:
-INSERT INTO RoomSummary(id, name, unread_notif_count, unread_highlight_count, last_event)
-VALUES(?,?,?,?,?);
+INSERT INTO RoomSummary(sessionId, id, name, unread_notif_count, unread_highlight_count, last_event)
+VALUES(?,?,?,?,?,?);
 
 updateRoomSummary:
 UPDATE RoomSummary
 SET name = ?, unread_notif_count = ?, unread_highlight_count = ?, last_event = ?
-WHERE(id = ?);
+WHERE(sessionId = ? AND id = ?);
 
 
 
 CREATE TABLE IF NOT EXISTS RoomState (
+ sessionId INTEGER NOT NULL,
  roomId TEXT NOT NULL,
  type TEXT NOT NULL,
  stateKey TEXT NOT NULL,
  data TEXT NOT NULL,
- PRIMARY KEY (roomId, type, stateKey)
+ PRIMARY KEY (sessionId, roomId, type, stateKey)
 );
 
 insertStateEvent:
-INSERT INTO RoomState(roomId, type, stateKey, data)
-VALUES(?,?,?,?);
+INSERT INTO RoomState(sessionId, roomId, type, stateKey, data)
+VALUES(?,?,?,?,?);
 
 updateStateEvent:
 UPDATE RoomState
 SET data = ?
-WHERE (roomId = ? AND type = ? AND stateKey = ?);
+WHERE (sessionId = ? AND roomId = ? AND type = ? AND stateKey = ?);
 
 getStateEvent:
 SELECT data FROM RoomState
-WHERE (roomId = ? AND type = ? AND stateKey = ?);
+WHERE (sessionId = ? AND roomId = ? AND type = ? AND stateKey = ?);
 
 getStateEvents:
 SELECT data FROM RoomState
-WHERE (roomId = ?);
+WHERE (sessionId = ? AND roomId = ?);
 
 
 
 CREATE TABLE IF NOT EXISTS RoomEvents (
  seqId TEXT PRIMARY KEY NOT NULL,
+ sessionId INTEGER NOT NULL,
  roomId TEXT NOT NULL,
  eventId TEXT NOT NULL,
  data TEXT NOT NULL,
  relatedEvent TEXT,
  prevBatch TEXT
 );
-CREATE UNIQUE INDEX IF NOT EXISTS RoomEventIndex ON RoomEvents (roomId, eventId);
-CREATE INDEX IF NOT EXISTS RelatedEventIndex ON RoomEvents (relatedEvent);
+CREATE UNIQUE INDEX IF NOT EXISTS RoomEventIndex ON RoomEvents (sessionId, roomId, eventId);
+CREATE INDEX IF NOT EXISTS RelatedEventIndex ON RoomEvents (sessionId, relatedEvent);
 
 minId:
 SELECT MIN(seqId) FROM RoomEvents;
@@ -133,37 +139,37 @@ SELECT MAX(seqId) FROM RoomEvents
 WHERE (seqId < ?);
 
 addRoomEvent:
-INSERT INTO RoomEvents(seqId, roomId, eventId, data, relatedEvent, prevBatch)
-VALUES(?,?,?,?,?,?);
+INSERT INTO RoomEvents(seqId, sessionId, roomId, eventId, data, relatedEvent, prevBatch)
+VALUES(?,?,?,?,?,?,?);
 
 updatePrevBatch:
 UPDATE RoomEvents
 SET prevBatch = ?
-WHERE (roomId = ? AND eventId = ?);
+WHERE (sessionId = ? AND roomId = ? AND eventId = ?);
 
 getRoomEventAndIdx:
 SELECT data,seqId,prevBatch FROM RoomEvents
-WHERE (roomId = ? AND eventId = ?)
+WHERE (sessionId = ? AND roomId = ? AND eventId = ?)
 LIMIT 1;
 
 getRoomEventsBackwardsFromPointReversed:
 SELECT data,seqId,prevBatch FROM RoomEvents
-WHERE (roomId = ?) AND (seqId < ?)
+WHERE (sessionId = ? AND roomId = ?) AND (seqId < ?)
 ORDER BY seqId DESC
 LIMIT ?;
 
 getRoomEventsForwardsFromPoint:
 SELECT data,seqId,prevBatch FROM RoomEvents
-WHERE (roomId = ?) AND (seqId > ?)
+WHERE (sessionId = ? AND roomId = ?) AND (seqId > ?)
 ORDER BY seqId ASC
 LIMIT ?;
 
 getMostRecentRoomEvent:
 SELECT data,seqId,prevBatch FROM RoomEvents
-WHERE (roomId = ?)
+WHERE (sessionId = ? AND roomId = ?)
 ORDER BY seqId DESC
 LIMIT 1;
 
 getRelatedEvents:
 SELECT data,seqId FROM RoomEvents
-WHERE (roomId = ?) AND (relatedEvent IN ?);
+WHERE (sessionId = ? AND roomId = ?) AND (relatedEvent IN ?);

--- a/serif_shared/src/commonMain/sqldelight/xyz/room409/serif/serif_shared/db/SessionDb.sq
+++ b/serif_shared/src/commonMain/sqldelight/xyz/room409/serif/serif_shared/db/SessionDb.sq
@@ -120,7 +120,7 @@ CREATE TABLE IF NOT EXISTS RoomEvents (
  prevBatch TEXT
 );
 CREATE UNIQUE INDEX IF NOT EXISTS RoomEventIndex ON RoomEvents (roomId, eventId);
-CREATE UNIQUE INDEX IF NOT EXISTS RelatedEventIndex ON RoomEvents (relatedEvent);
+CREATE INDEX IF NOT EXISTS RelatedEventIndex ON RoomEvents (relatedEvent);
 
 minId:
 SELECT MIN(seqId) FROM RoomEvents;

--- a/serif_shared/src/commonMain/sqldelight/xyz/room409/serif/serif_shared/db/SessionDb.sq
+++ b/serif_shared/src/commonMain/sqldelight/xyz/room409/serif/serif_shared/db/SessionDb.sq
@@ -57,6 +57,33 @@ DELETE FROM MediaCache;
 
 
 
+CREATE TABLE IF NOT EXISTS RoomSummary (
+    id TEXT PRIMARY KEY NOT NULL,
+    name TEXT NOT NULL,
+    unread_notif_count INTEGER NOT NULL,
+    unread_highlight_count INTEGER NOT NULL,
+    last_event TEXT
+);
+
+getRooms:
+SELECT * FROM RoomSummary;
+
+getRoom:
+SELECT * FROM RoomSummary
+WHERE (id = ? )
+LIMIT 1;
+
+insertRoomSummary:
+INSERT INTO RoomSummary(id, name, unread_notif_count, unread_highlight_count, last_event)
+VALUES(?,?,?,?,?);
+
+updateRoomSummary:
+UPDATE RoomSummary
+SET name = ?, unread_notif_count = ?, unread_highlight_count = ?, last_event = ?
+WHERE(id = ?);
+
+
+
 CREATE TABLE IF NOT EXISTS RoomState (
  roomId TEXT NOT NULL,
  type TEXT NOT NULL,
@@ -82,8 +109,6 @@ getStateEvents:
 SELECT data FROM RoomState
 WHERE (roomId = ?);
 
-getRooms:
-SELECT DISTINCT roomId FROM RoomState;
 
 
 CREATE TABLE IF NOT EXISTS RoomEvents (

--- a/serif_swing/src/main/kotlin/serif_swing/App.kt
+++ b/serif_swing/src/main/kotlin/serif_swing/App.kt
@@ -865,6 +865,7 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
             val in_lower_buffer = m.messages.size - ended < buffer_space
             val tracking_current = m.message_window_base == null
             val no_request_out = (m.window_back_length + m.window_forward_length + 1) <= m.messages.size
+            println("in_upper_buffer $in_upper_buffer ($began < $buffer_space) && no_request_out $no_request_out (${m.window_back_length} + ${m.window_forward_length} + 1) <= ${m.messages.size}")
             if (in_upper_buffer && no_request_out) {
                 javax.swing.SwingUtilities.invokeLater({
                     transition(m.refresh(desired_window_half, m.messages[began].id, desired_window_half), true)

--- a/serif_swing/src/main/kotlin/serif_swing/App.kt
+++ b/serif_swing/src/main/kotlin/serif_swing/App.kt
@@ -657,6 +657,10 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
         }
         attString
     }
+    val room_name = SmoothLabel("")
+    fun setRoomName(name: String) {
+        room_name.setText("Room Name: $name")
+    }
     val mk_sender = { msg: SharedUiMessage ->
         val render_text = { msg: SharedUiMessage ->
             if (msg.reactions.size > 0) {
@@ -865,7 +869,7 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
             val in_lower_buffer = m.messages.size - ended < buffer_space
             val tracking_current = m.message_window_base == null
             val no_request_out = (m.window_back_length + m.window_forward_length + 1) <= m.messages.size
-            println("in_upper_buffer $in_upper_buffer ($began < $buffer_space) && no_request_out $no_request_out (${m.window_back_length} + ${m.window_forward_length} + 1) <= ${m.messages.size}")
+            //println("in_upper_buffer $in_upper_buffer ($began < $buffer_space) && no_request_out $no_request_out (${m.window_back_length} + ${m.window_forward_length} + 1) <= ${m.messages.size}")
             if (in_upper_buffer && no_request_out) {
                 javax.swing.SwingUtilities.invokeLater({
                     transition(m.refresh(desired_window_half, m.messages[began].id, desired_window_half), true)
@@ -885,6 +889,11 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
     var edited_event_id = ""
     init {
         panel.layout = BorderLayout()
+        setRoomName(m.name)
+        panel.add(
+            room_name,
+            BorderLayout.PAGE_START
+        )
 
         recycling_message_list.reset(last_window_width, m.messages)
         val scroll_pane = JScrollPane(
@@ -967,6 +976,7 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
         } else {
             m = new_m
         }
+        setRoomName(m.name)
     }
     private fun openUrl(href: String) {
         // In the background, so that GUI doesn't freeze


### PR DESCRIPTION
This is a big one!
I really do feel like this makes one big step from prototype to something more real.
We've finally gotten a realistic kind of architecture at each level, while it's wildly unfinished, it's no longer a toy!

Anyway, this PR replaces our continuous globbing together of returned sync responses into one large sync response and instead backs everything with a database! No more unlimited runtime memory growth and losing everything when quitting. And the window system of the GUI now pushes all the way down into the database queries! The GUI asks for a window of drawable events, and the MatrixSession asks for ranges from the database until it has enough *drawable* events, and then asks the database for all events that modify this one (edits & reactions) so that they can be included and combined properly.

Maintaining the order of events that the server gives us while dealing with missing chunks, backfilling, and efficient insertion isn't easy, but I think our solution is decent (thanks to stackoverflow for the inspiration for using strings as variable precision numbers, though we didn't use any code from there). Yep, basically we use strings as variable precision numbers, and enforce that we never have an entry end in 'a', so we can always insert between any two events. The minimum logical endpoint is 'a' and the maximum is an infinite string of z's.

There's some other fixup around, like setting sync server timeout to 30 seconds as recommended in #matrix-dev, and CIO the now explicit HttpEngine's timeout to 35 seconds to accommodate it, etc.

This is my first time writing serious database stuff, so there's likely some stuff to improve, please let me know what issues you see!