### PR TITLE
Rich replies

### DIFF
--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Events.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Events.kt
@@ -195,14 +195,16 @@ class AudioRMEC(
     override val body: String = "<missing message body, likely redacted>",
     override val msgtype: String = "<missing type, likely redacted>",
     val info: AudioInfo,
-    val url: String
+    val url: String,
+    @SerialName("m.relates_to") val relates_to: RelationBlock? = null
 ) : RoomMessageEventContent()
 @Serializable
 class VideoRMEC(
     override val body: String = "<missing message body, likely redacted>",
     override val msgtype: String = "<missing type, likely redacted>",
     val info: VideoInfo,
-    val url: String
+    val url: String,
+    @SerialName("m.relates_to") val relates_to: RelationBlock? = null
 ) : RoomMessageEventContent()
 @Serializable
 class FileRMEC(
@@ -210,13 +212,15 @@ class FileRMEC(
     override val msgtype: String = "<missing type, likely redacted>",
     val info: FileInfo,
     val filename: String = "",
-    val url: String
+    val url: String,
+    @SerialName("m.relates_to") val relates_to: RelationBlock? = null
 ) : RoomMessageEventContent()
 @Serializable
 class LocationRMEC(
     override val body: String = "<missing message body, likely redacted>",
     override val msgtype: String = "<missing type, likely redacted>",
-    val geo_uri: String
+    val geo_uri: String,
+    @SerialName("m.relates_to") val relates_to: RelationBlock? = null
 ) : RoomMessageEventContent()
 @Serializable
 class FallbackRMEC(

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Events.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/Events.kt
@@ -187,7 +187,8 @@ class ImageRMEC(
     override val body: String = "<missing message body, likely redacted>",
     override val msgtype: String = "<missing type, likely redacted>",
     val info: ImageInfo,
-    val url: String
+    val url: String,
+    @SerialName("m.relates_to") val relates_to: RelationBlock? = null
 ) : RoomMessageEventContent()
 @Serializable
 class AudioRMEC(

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
@@ -178,7 +178,11 @@ fun toSharedUiMessageList(msession: MatrixSession, username: String, room_id: St
 
             val in_reply_to = when(msg_content) {
                 is TextRMEC -> msg_content.relates_to
+                is AudioRMEC -> msg_content.relates_to
                 is ImageRMEC -> msg_content.relates_to
+                is FileRMEC -> msg_content.relates_to
+                is LocationRMEC -> msg_content.relates_to
+                is VideoRMEC -> msg_content.relates_to
                 else -> null
             }?.in_reply_to?.event_id?.let { in_reply_to_id ->
                 toSharedUiMessageList(msession, username, room_id, 0, in_reply_to_id, 0).first.firstOrNull()

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
@@ -194,16 +194,16 @@ fun toSharedUiMessageList(msession: MatrixSession, username: String, room_id: St
             }
             when (msg_content) {
                 is TextRMEC -> {
+                    val in_reply_to = msg_content.relates_to?.in_reply_to?.event_id?.let { in_reply_to_id ->
+                        toSharedUiMessageList(msession, username, room_id, 0, in_reply_to_id, 0).first.first()
+                    }
                     val normal_msg_builder = {
-                        val in_reply_to = msg_content.relates_to?.in_reply_to?.event_id?.let { in_reply_to_id ->
-                            toSharedUiMessageList(msession, username, room_id, 0, in_reply_to_id, 0).first.first()
-                        }
                         SharedUiMessagePlain(it.sender, it.content.body, it.event_id, it.origin_server_ts, reactions, in_reply_to)
                     }
                     if((msg_content.new_content != null) && (msg_content.relates_to?.event_id == null)) {
                         //This is a poorly formed edit
                         //No idea which event this edit is editing, just display fallback msg
-                        SharedUiMessagePlain(it.sender, it.content.body, it.event_id, it.origin_server_ts, reactions)
+                        SharedUiMessagePlain(it.sender, it.content.body, it.event_id, it.origin_server_ts, reactions, in_reply_to)
                     } else {
                         if(is_edit_content(msg_content)) {
                             //Don't display edits
@@ -220,7 +220,7 @@ fun toSharedUiMessageList(msession: MatrixSession, username: String, room_id: St
                                         edited.id,
                                         it.origin_server_ts,
                                         reactions,
-                                        null // TODO: support editing replies msg_content.relates_to?.in_reply_to?.event_id ?: ""
+                                        in_reply_to
                                         )
                                 } else {
                                     normal_msg_builder()

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
@@ -175,28 +175,33 @@ fun toSharedUiMessageList(msession: MatrixSession, username: String, room_id: St
         if (it as? RoomMessageEvent != null) {
             val reactions = reaction_maps.get(it.event_id)?.entries?.map { (key, senders) -> Pair(key, senders?.toSet() ?: setOf())}?.toMap() ?: mapOf()
             val msg_content = it.content
+
+            val in_reply_to = when(msg_content) {
+                is TextRMEC -> msg_content.relates_to
+                is ImageRMEC -> msg_content.relates_to
+                else -> null
+            }?.in_reply_to?.event_id?.let { in_reply_to_id ->
+                toSharedUiMessageList(msession, username, room_id, 0, in_reply_to_id, 0).first.firstOrNull()
+            }
+
             var generate_media_msg = { url: String, func: (String,String,String,Long,Map<String,Set<String>>,SharedUiMessage?,String) -> SharedUiMessage ->
                 when (val url_local = msession.getLocalMediaPathFromUrl(url)) {
                     is Success -> {
                         func(
                             it.sender, it.content.body, it.event_id,
-                            it.origin_server_ts, reactions, null, // TODO: support replies as images
-                            url_local.value
+                            it.origin_server_ts, reactions, in_reply_to, url_local.value
                         )
                     }
                     is Error -> {
                         SharedUiMessagePlain(
                             it.sender, "Failed to load media ${url}",
-                            it.event_id, it.origin_server_ts, reactions, null // TODO: support replies as images
+                            it.event_id, it.origin_server_ts, reactions, in_reply_to
                         )
                     }
                 }
             }
             when (msg_content) {
                 is TextRMEC -> {
-                    val in_reply_to = msg_content.relates_to?.in_reply_to?.event_id?.let { in_reply_to_id ->
-                        toSharedUiMessageList(msession, username, room_id, 0, in_reply_to_id, 0).first.first()
-                    }
                     val transform_body = { body_message: String ->
                         if (in_reply_to != null) {
                             var stripping = true

--- a/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
+++ b/serif_shared/src/commonMain/kotlin/xyz/room409/serif/serif_shared/States.kt
@@ -80,7 +80,7 @@ abstract class SharedUiMessage() {
     abstract val message: String
     abstract val id: String
     abstract val timestamp: Long
-    abstract val replied_event: String
+    abstract val replied_event: SharedUiMessage?
     abstract val reactions: Map<String, Set<String>>
 }
 data class SharedUiMessagePlain(
@@ -89,7 +89,7 @@ data class SharedUiMessagePlain(
     override val id: String,
     override val timestamp: Long,
     override val reactions: Map<String, Set<String>>,
-    override val replied_event: String = ""
+    override val replied_event: SharedUiMessage? = null
 ) : SharedUiMessage()
 class SharedUiImgMessage(
     override val sender: String,
@@ -97,7 +97,7 @@ class SharedUiImgMessage(
     override val id: String,
     override val timestamp: Long,
     override val reactions: Map<String, Set<String>>,
-    override val replied_event: String = "",
+    override val replied_event: SharedUiMessage? = null,
     val url: String
 ) : SharedUiMessage()
 class SharedUiAudioMessage(
@@ -106,7 +106,7 @@ class SharedUiAudioMessage(
     override val id: String,
     override val timestamp: Long,
     override val reactions: Map<String, Set<String>>,
-    override val replied_event: String = "",
+    override val replied_event: SharedUiMessage? = null,
     val url: String
 ) : SharedUiMessage()
 class SharedUiVideoMessage(
@@ -115,7 +115,7 @@ class SharedUiVideoMessage(
     override val id: String,
     override val timestamp: Long,
     override val reactions: Map<String, Set<String>>,
-    override val replied_event: String = "",
+    override val replied_event: SharedUiMessage? = null,
     val url: String
 ) : SharedUiMessage()
 class SharedUiFileMessage(
@@ -127,7 +127,7 @@ class SharedUiFileMessage(
     val filename: String,
     val mimetype: String,
     val url: String,
-    override val replied_event: String = "",
+    override val replied_event: SharedUiMessage? = null,
 ) : SharedUiMessage()
 class SharedUiLocationMessage(
     override val sender: String,
@@ -136,9 +136,138 @@ class SharedUiLocationMessage(
     override val timestamp: Long,
     override val reactions: Map<String, Set<String>>,
     val location: String,
-    override val replied_event: String = "",
+    override val replied_event: SharedUiMessage? = null,
 ) : SharedUiMessage()
 
+fun toSharedUiMessageList(msession: MatrixSession, username: String, room_id: String, window_back_length: Int, message_window_base: String?, window_forward_length: Int): Pair<List<SharedUiMessage>, Boolean> {
+    val edit_maps: MutableMap<String,ArrayList<SharedUiMessage>> = mutableMapOf()
+    val reaction_maps: MutableMap<String, MutableMap<String, MutableSet<String>>> = mutableMapOf()
+
+    val (event_range, tracking_live) = msession.getReleventRoomEventsForWindow(room_id, window_back_length, message_window_base, window_forward_length)
+
+    event_range.forEach {
+        if (it as? RoomMessageEvent != null) {
+            val msg_content = it.content
+            if (msg_content is ReactionRMEC) {
+                val relates_to = msg_content!!.relates_to!!.event_id!!
+                val key = msg_content!!.relates_to!!.key!!
+                val reactions_for_msg = reaction_maps.getOrPut(relates_to, { mutableMapOf() })
+                reactions_for_msg.getOrPut(key, { mutableSetOf() }).add(it.sender)
+            } else if (msg_content is TextRMEC) {
+                if (is_edit_content(msg_content)) {
+                    // This is an edit
+                    val replaced_id = msg_content!!.relates_to!!.event_id!!
+                    val reactions = reaction_maps.get(replaced_id)?.entries?.map { (key, senders) -> Pair(key, senders?.toSet() ?: setOf())}?.toMap() ?: mapOf()
+                    val edit_msg = SharedUiMessagePlain(it.sender, msg_content!!.new_content!!.body,
+                        it.event_id, it.origin_server_ts, reactions)
+
+                    if (edit_maps.contains(replaced_id)) {
+                        edit_maps.get(replaced_id)!!.add(edit_msg)
+                    } else {
+                        edit_maps.put(replaced_id, arrayListOf(edit_msg))
+                    }
+                }
+            }
+        }
+    }
+    val edits: Map<String,ArrayList<SharedUiMessage>> = edit_maps.toMap()
+    val messages = event_range.map {
+        if (it as? RoomMessageEvent != null) {
+            val reactions = reaction_maps.get(it.event_id)?.entries?.map { (key, senders) -> Pair(key, senders?.toSet() ?: setOf())}?.toMap() ?: mapOf()
+            val msg_content = it.content
+            var generate_media_msg = { url: String, func: (String,String,String,Long,Map<String,Set<String>>,SharedUiMessage?,String) -> SharedUiMessage ->
+                when (val url_local = msession.getLocalMediaPathFromUrl(url)) {
+                    is Success -> {
+                        func(
+                            it.sender, it.content.body, it.event_id,
+                            it.origin_server_ts, reactions, null, // TODO: support replies as images
+                            url_local.value
+                        )
+                    }
+                    is Error -> {
+                        SharedUiMessagePlain(
+                            it.sender, "Failed to load media ${url}",
+                            it.event_id, it.origin_server_ts, reactions, null // TODO: support replies as images
+                        )
+                    }
+                }
+            }
+            when (msg_content) {
+                is TextRMEC -> {
+                    val normal_msg_builder = {
+                        val in_reply_to = msg_content.relates_to?.in_reply_to?.event_id?.let { in_reply_to_id ->
+                            toSharedUiMessageList(msession, username, room_id, 0, in_reply_to_id, 0).first.first()
+                        }
+                        SharedUiMessagePlain(it.sender, it.content.body, it.event_id, it.origin_server_ts, reactions, in_reply_to)
+                    }
+                    if((msg_content.new_content != null) && (msg_content.relates_to?.event_id == null)) {
+                        //This is a poorly formed edit
+                        //No idea which event this edit is editing, just display fallback msg
+                        SharedUiMessagePlain(it.sender, it.content.body, it.event_id, it.origin_server_ts, reactions)
+                    } else {
+                        if(is_edit_content(msg_content)) {
+                            //Don't display edits
+                            null
+                        } else {
+                            //This is a text message, check for any edits of this message
+                            if(edits.contains(it.event_id)) {
+                                val possible_edits = edits.get(it.event_id)!!
+                                val edited = possible_edits.lastOrNull { it.sender.contains(username) }
+                                if(edited != null) {
+                                    SharedUiMessagePlain(
+                                        it.sender,
+                                        "${edited.message} (edited)",
+                                        edited.id,
+                                        it.origin_server_ts,
+                                        reactions,
+                                        null // TODO: support editing replies msg_content.relates_to?.in_reply_to?.event_id ?: ""
+                                        )
+                                } else {
+                                    normal_msg_builder()
+                                }
+                            } else {
+                                //No edits for this event
+                                normal_msg_builder()
+                            }
+                        }
+                    }
+                }
+                is ImageRMEC -> generate_media_msg(msg_content.url, ::SharedUiImgMessage)
+                is AudioRMEC -> generate_media_msg(msg_content.url, ::SharedUiAudioMessage)
+                is VideoRMEC -> generate_media_msg(msg_content.url, ::SharedUiVideoMessage)
+                is FileRMEC -> {
+                    SharedUiFileMessage(
+                        it.sender, it.content.body, it.event_id,
+                        it.origin_server_ts, reactions, msg_content.filename,
+                        msg_content.info.mimetype, msg_content.url
+                    )
+                }
+                is LocationRMEC -> {
+                    SharedUiLocationMessage(
+                        it.sender, it.content.body, it.event_id,
+                        it.origin_server_ts, reactions, msg_content.geo_uri
+                    )
+                }
+                is ReactionRMEC -> null
+                else -> SharedUiMessagePlain(it.sender, "UNHANDLED ROOM MESSAGE EVENT!!! ${it.content.body}", it.event_id, it.origin_server_ts, reactions)
+            }
+        } else if (it as? RoomEvent != null) {
+            // This won't actually happen currently,
+            // as all non RoomMessageEvents will be filtered out by the
+            // isStandaloneEvent filter when pulling from the database.
+            // In general, keeping the two up to date will require
+            // some effort.
+            // TODO: something else? Either always show, or always hide?
+            println("unhandled room event $it")
+            SharedUiMessagePlain(it.sender, "UNHANDLED ROOM EVENT!!! $it", it.event_id, it.origin_server_ts, mapOf())
+        } else {
+            println("IMPOSSIBLE unhandled non room event $it")
+            throw Exception("IMPOSSIBLE unhandled non room event $it")
+            SharedUiMessagePlain("impossible", "impossible", "impossible", 0, mapOf())
+        }
+    }.filterNotNull()
+    return Pair(messages, tracking_live)
+}
 
 class MatrixChatRoom(private val msession: MatrixSession, val room_id: String, val name: String, val window_back_length: Int, message_window_base_in: String?, window_forward_length_in: Int) : MatrixState() {
     val username = msession.user
@@ -148,133 +277,14 @@ class MatrixChatRoom(private val msession: MatrixSession, val room_id: String, v
     val pinned: List<String>
     init {
         pinned = msession.getPinnedEvents(room_id)
-
-        val edit_maps: MutableMap<String,ArrayList<SharedUiMessage>> = mutableMapOf()
-        val reaction_maps: MutableMap<String, MutableMap<String, MutableSet<String>>> = mutableMapOf()
-
-        val (event_range, tracking_live) = msession.getReleventRoomEventsForWindow(room_id, window_back_length, message_window_base_in, window_forward_length_in)
+        val (got_messages, tracking_live) = toSharedUiMessageList(msession, username, room_id, window_back_length, message_window_base_in, window_forward_length_in)
+        messages = got_messages
         if (tracking_live) {
             message_window_base = null
         } else {
             message_window_base = message_window_base_in
         }
 
-        event_range.forEach {
-            if (it as? RoomMessageEvent != null) {
-                val msg_content = it.content
-                if (msg_content is ReactionRMEC) {
-                    val relates_to = msg_content!!.relates_to!!.event_id!!
-                    val key = msg_content!!.relates_to!!.key!!
-                    val reactions_for_msg = reaction_maps.getOrPut(relates_to, { mutableMapOf() })
-                    reactions_for_msg.getOrPut(key, { mutableSetOf() }).add(it.sender)
-                } else if (msg_content is TextRMEC) {
-                    if (is_edit_content(msg_content)) {
-                        // This is an edit
-                        val replaced_id = msg_content!!.relates_to!!.event_id!!
-                        val reactions = reaction_maps.get(replaced_id)?.entries?.map { (key, senders) -> Pair(key, senders?.toSet() ?: setOf())}?.toMap() ?: mapOf()
-                        val edit_msg = SharedUiMessagePlain(it.sender, msg_content!!.new_content!!.body,
-                            it.event_id, it.origin_server_ts, reactions)
-
-                        if (edit_maps.contains(replaced_id)) {
-                            edit_maps.get(replaced_id)!!.add(edit_msg)
-                        } else {
-                            edit_maps.put(replaced_id, arrayListOf(edit_msg))
-                        }
-                    }
-                }
-            }
-        }
-        val edits: Map<String,ArrayList<SharedUiMessage>> = edit_maps.toMap()
-        messages = event_range.map {
-            if (it as? RoomMessageEvent != null) {
-                val reactions = reaction_maps.get(it.event_id)?.entries?.map { (key, senders) -> Pair(key, senders?.toSet() ?: setOf())}?.toMap() ?: mapOf()
-                val msg_content = it.content
-                var generate_media_msg = { url: String, func: (String,String,String,Long,Map<String,Set<String>>,String,String) -> SharedUiMessage ->
-                    when (val url_local = msession.getLocalMediaPathFromUrl(url)) {
-                        is Success -> {
-                            func(
-                                it.sender, it.content.body, it.event_id,
-                                it.origin_server_ts, reactions, "", url_local.value
-                            )
-                        }
-                        is Error -> {
-                            SharedUiMessagePlain(
-                                it.sender, "Failed to load media ${url}",
-                                it.event_id, it.origin_server_ts, reactions, ""
-                            )
-                        }
-                    }
-                }
-                when (msg_content) {
-                    is TextRMEC -> {
-                        val normal_msg_builder = {
-                            SharedUiMessagePlain(it.sender, it.content.body, it.event_id, it.origin_server_ts, reactions, msg_content.relates_to?.in_reply_to?.event_id ?: "")
-                        }
-                        if((msg_content.new_content != null) && (msg_content.relates_to?.event_id == null)) {
-                            //This is a poorly formed edit
-                            //No idea which event this edit is editing, just display fallback msg
-                            SharedUiMessagePlain(it.sender, it.content.body, it.event_id, it.origin_server_ts, reactions)
-                        } else {
-                            if(is_edit_content(msg_content)) {
-                                //Don't display edits
-                                null
-                            } else {
-                                //This is a text message, check for any edits of this message
-                                if(edits.contains(it.event_id)) {
-                                    val possible_edits = edits.get(it.event_id)!!
-                                    val edited = possible_edits.lastOrNull { it.sender.contains(username) }
-                                    if(edited != null) {
-                                        SharedUiMessagePlain(
-                                            it.sender,
-                                            "${edited.message} (edited)",
-                                            edited.id,
-                                            it.origin_server_ts,
-                                            reactions,
-                                            msg_content.relates_to?.in_reply_to?.event_id ?: "")
-                                    } else {
-                                        normal_msg_builder()
-                                    }
-                                } else {
-                                    //No edits for this event
-                                    normal_msg_builder()
-                                }
-                            }
-                        }
-                    }
-                    is ImageRMEC -> generate_media_msg(msg_content.url, ::SharedUiImgMessage)
-                    is AudioRMEC -> generate_media_msg(msg_content.url, ::SharedUiAudioMessage)
-                    is VideoRMEC -> generate_media_msg(msg_content.url, ::SharedUiVideoMessage)
-                    is FileRMEC -> {
-                        SharedUiFileMessage(
-                            it.sender, it.content.body, it.event_id,
-                            it.origin_server_ts, reactions, msg_content.filename,
-                            msg_content.info.mimetype, msg_content.url
-                        )
-                    }
-                    is LocationRMEC -> {
-                        SharedUiLocationMessage(
-                            it.sender, it.content.body, it.event_id,
-                            it.origin_server_ts, reactions, msg_content.geo_uri
-                        )
-                    }
-                    is ReactionRMEC -> null
-                    else -> SharedUiMessagePlain(it.sender, "UNHANDLED ROOM MESSAGE EVENT!!! ${it.content.body}", it.event_id, it.origin_server_ts, reactions)
-                }
-            } else if (it as? RoomEvent != null) {
-                // This won't actually happen currently,
-                // as all non RoomMessageEvents will be filtered out by the
-                // isStandaloneEvent filter when pulling from the database.
-                // In general, keeping the two up to date will require
-                // some effort.
-                // TODO: something else? Either always show, or always hide?
-                println("unhandled room event $it")
-                SharedUiMessagePlain(it.sender, "UNHANDLED ROOM EVENT!!! $it", it.event_id, it.origin_server_ts, mapOf())
-            } else {
-                println("IMPOSSIBLE unhandled non room event $it")
-                throw Exception("IMPOSSIBLE unhandled non room event $it")
-                SharedUiMessagePlain("impossible", "impossible", "impossible", 0, mapOf())
-            }
-        }.filterNotNull()
     }
     val window_forward_length: Int = if (message_window_base != null) { window_forward_length_in } else { 0 }
     fun sendMessage(msg: String): MatrixState {

--- a/serif_swing/src/main/kotlin/serif_swing/App.kt
+++ b/serif_swing/src/main/kotlin/serif_swing/App.kt
@@ -866,11 +866,11 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
                 Triple(listOf(sender, btn, menu), { Unit }, { msg, repaint_cell -> set_sender(msg); set_menu(msg); set_loc(msg); })
             },
             "text" to { msg, repaint_cell ->
-                val message = SerifText(stringToAttributedURLString(msg.message))
+                val message = SerifText(stringToAttributedURLString(msg.message + "reply: ${msg.replied_event}"))
                 message.addMouseListener(URLMouseListener(message))
                 val (sender, set_sender) = mk_sender(msg)
                 val (menu, set_menu) = mk_menu(msg)
-                Triple(listOf(sender, message, menu), { Unit }, { msg, repaint_cell -> message.setText(stringToAttributedURLString(msg.message)); set_sender(msg); set_menu(msg) })
+                Triple(listOf(sender, message, menu), { Unit }, { msg, repaint_cell -> message.setText(stringToAttributedURLString(msg.message + "reply: ${msg.replied_event}")); set_sender(msg); set_menu(msg) })
             }
         ),
        { began, ended ->

--- a/serif_swing/src/main/kotlin/serif_swing/App.kt
+++ b/serif_swing/src/main/kotlin/serif_swing/App.kt
@@ -505,7 +505,7 @@ class RecyclingList<T>(private var our_width: Int, val choose: (T) -> String, va
                         var sub_offset = sy
                         for (c in sub_components) {
                             if (e.point.y < sub_offset + c.height) {
-                                val new_e = MouseEvent(c, e.id, e.getWhen(), e.modifiers, e.x, e.y-sub_offset, e.xOnScreen, e.yOnScreen, e.clickCount, e.isPopupTrigger(), e.button)
+                                val new_e = MouseEvent(c, e.id, e.getWhen(), e.modifiers, e.x-indent, e.y-sub_offset, e.xOnScreen, e.yOnScreen, e.clickCount, e.isPopupTrigger(), e.button)
                                 // a hack so that stuff like buttons have a proper parent when the reply/edit menu pops up and uses it
                                 add(c)
                                 c.dispatchEvent(new_e)
@@ -586,11 +586,11 @@ class RecyclingList<T>(private var our_width: Int, val choose: (T) -> String, va
                     c.setSize(our_width, 1000)
                     val d = c.getPreferredSize()
                     if(c is JButton && (c as JButton).getText() == "...") {
-                        c.setSize(our_width-indent, d.height)
-                        c.setBounds(indent, our_height, our_width-indent, d.height)
-                    } else {
                         c.setSize(d.width, d.height)
                         c.setBounds(indent, our_height, d.width, d.height)
+                    } else {
+                        c.setSize(our_width-indent, d.height)
+                        c.setBounds(indent, our_height, our_width-indent, d.height)
                     }
                     height_delta += c.height
                 }

--- a/serif_swing/src/main/kotlin/serif_swing/App.kt
+++ b/serif_swing/src/main/kotlin/serif_swing/App.kt
@@ -672,6 +672,10 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
     fun setRoomName(name: String) {
         room_name.setText("Room Name: $name")
     }
+    fun updatePinOptionText(event_id: String, menu_item: JMenuItem) {
+        val pin_str = if(m.pinned.contains(event_id)) { "Unpin" } else { "Pin" }
+        menu_item.setText(pin_str)
+    }
     val mk_sender = { msg: SharedUiMessage ->
         val render_text = { msg: SharedUiMessage ->
             if (msg.reactions.size > 0) {

--- a/serif_swing/src/main/kotlin/serif_swing/App.kt
+++ b/serif_swing/src/main/kotlin/serif_swing/App.kt
@@ -866,11 +866,11 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
                 Triple(listOf(sender, btn, menu), { Unit }, { msg, repaint_cell -> set_sender(msg); set_menu(msg); set_loc(msg); })
             },
             "text" to { msg, repaint_cell ->
-                val message = SerifText(stringToAttributedURLString(msg.message + "reply: ${msg.replied_event}"))
+                val message = SerifText(stringToAttributedURLString((msg.replied_event?.let { "in reply to ${it}: " } ?: "") + msg.message))
                 message.addMouseListener(URLMouseListener(message))
                 val (sender, set_sender) = mk_sender(msg)
                 val (menu, set_menu) = mk_menu(msg)
-                Triple(listOf(sender, message, menu), { Unit }, { msg, repaint_cell -> message.setText(stringToAttributedURLString(msg.message + "reply: ${msg.replied_event}")); set_sender(msg); set_menu(msg) })
+                Triple(listOf(sender, message, menu), { Unit }, { msg, repaint_cell -> message.setText(stringToAttributedURLString((msg.replied_event?.let { "in reply to ${it}: " } ?: "") + msg.message)); set_sender(msg); set_menu(msg) })
             }
         ),
        { began, ended ->

--- a/serif_swing/src/main/kotlin/serif_swing/App.kt
+++ b/serif_swing/src/main/kotlin/serif_swing/App.kt
@@ -693,22 +693,25 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
         var msg = msg_in
         val msg_action_button = SmoothButton("...")
         msg_action_button.addActionListener({
-            val reply_option = JMenuItem("Reply")
-            reply_option.addActionListener({
-                println("Now writing a reply")
-                replied_event_id = msg.id
-            })
-            val react_option = JMenuItem("React")
-            react_option.addActionListener({
-                println("Now writing a reaction")
-                reacted_event_id = msg.id
-            })
-            val edit_option = JMenuItem("Edit")
-            edit_option.addActionListener({
-                println("Now editing a message")
-                edited_event_id = msg.id
-                message_field.text = msg.message
-            })
+			val reply_option = JMenuItem("Reply")
+			reply_option.addActionListener({
+				msg_context_label.setText("Replying to: ${msg.sender} ${msg.message}")
+				msg_context_panel.setVisible(true)
+				replied_event_id = msg.id
+			})
+			val react_option = JMenuItem("React")
+			react_option.addActionListener({
+				msg_context_label.setText("Reacting to: ${msg.sender} ${msg.message}")
+				msg_context_panel.setVisible(true)
+				reacted_event_id = msg.id
+			})
+			val edit_option = JMenuItem("Edit")
+			edit_option.addActionListener({
+				msg_context_label.setText("Editing: ${msg.message}")
+				msg_context_panel.setVisible(true)
+				edited_event_id = msg.id
+				message_field.text = msg.message
+			})
             val pin_option = JMenuItem()
             updatePinOptionText(msg.id,pin_option)
             pin_option.addActionListener({
@@ -818,11 +821,11 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
                 val (sender, set_sender) = mk_sender(msg)
                 val (menu, set_menu) = mk_menu(msg)
                 RecyclableItemGeneratorResult(
-                    listOf(),
+                    msg.replied_event?.let { listOf(it) } ?: listOf(),
                     listOf(sender, play_btn, menu),
                     listOf(),
                     { Unit },
-                    { msg, repaint_cell -> set_sender(msg); set_menu(msg); audio_url = (msg as SharedUiAudioMessage).url; Pair(listOf(),listOf()) }
+                    { msg, repaint_cell -> set_sender(msg); set_menu(msg); audio_url = (msg as SharedUiAudioMessage).url; Pair(msg.replied_event?.let { listOf(it) } ?: listOf(), listOf()) }
                 )
             },
             "video" to { msg, repaint_cell ->
@@ -837,12 +840,15 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
 
                 val (sender, set_sender) = mk_sender(msg)
                 val (menu, set_menu) = mk_menu(msg)
+				if (msg.replied_event != null) {
+					println("Video reply!!! ${msg.replied_event}")
+				}
                 RecyclableItemGeneratorResult(
-                    listOf(),
+                    msg.replied_event?.let { listOf(it) } ?: listOf(),
                     listOf(sender, video_btn, menu),
                     listOf(),
                     { vp.clear() },
-                    { msg, repaint_cell -> set_sender(msg); set_menu(msg); vp.loadVideo((msg as SharedUiVideoMessage).url, video_btn, repaint_cell); Pair(listOf(),listOf()) }
+                    { msg, repaint_cell -> set_sender(msg); set_menu(msg); vp.loadVideo((msg as SharedUiVideoMessage).url, video_btn, repaint_cell); Pair(msg.replied_event?.let { listOf(it) } ?: listOf(), listOf()) }
                 )
             },
             "file" to { msg, repaint_cell ->
@@ -875,11 +881,11 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
                 val (sender, set_sender) = mk_sender(msg)
                 val (menu, set_menu) = mk_menu(msg)
                 RecyclableItemGeneratorResult(
-                    listOf(),
+                    msg.replied_event?.let { listOf(it) } ?: listOf(),
                     listOf(sender, btn, menu),
                     listOf(),
                     { Unit },
-                    { msg, repaint_cell -> set_sender(msg); set_menu(msg); set_down(msg); Pair(listOf(),listOf()) }
+                    { msg, repaint_cell -> set_sender(msg); set_menu(msg); set_down(msg); Pair(msg.replied_event?.let { listOf(it) } ?: listOf(), listOf()) }
                 )
             },
             "location" to { msg, repaint_cell ->
@@ -897,11 +903,11 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
                 val (sender, set_sender) = mk_sender(msg)
                 val (menu, set_menu) = mk_menu(msg)
                 RecyclableItemGeneratorResult(
-                    listOf(),
+                    msg.replied_event?.let { listOf(it) } ?: listOf(),
                     listOf(sender, btn, menu),
                     listOf(),
                     { Unit },
-                    { msg, repaint_cell -> set_sender(msg); set_menu(msg); set_loc(msg); Pair(listOf(),listOf()) }
+                    { msg, repaint_cell -> set_sender(msg); set_menu(msg); set_loc(msg); Pair(msg.replied_event?.let { listOf(it) } ?: listOf(), listOf()) }
                 )
             },
             "text" to { msg, repaint_cell ->

--- a/serif_swing/src/main/kotlin/serif_swing/App.kt
+++ b/serif_swing/src/main/kotlin/serif_swing/App.kt
@@ -794,14 +794,14 @@ class SwingChatRoom(val transition: (MatrixState, Boolean) -> Unit, val panel: J
                 val (sender, set_sender) = mk_sender(msg)
                 val (menu, set_menu) = mk_menu(msg)
                 RecyclableItemGeneratorResult(
-                    listOf(),
+                    msg.replied_event?.let { listOf(it) } ?: listOf(),
                     listOf(sender, JLabel(icon), menu),
                     listOf(),
                     { icon.setImageObserver(null) }, { msg, repaint_cell ->
                         set_icon_image(icon, msg as SharedUiImgMessage, repaint_cell)
                         set_sender(msg)
                         set_menu(msg)
-                        Pair(listOf(), listOf())
+                        Pair(msg.replied_event?.let { listOf(it) } ?: listOf(), listOf())
                     }
                 )
             },


### PR DESCRIPTION
~~Working PoC, but need to add the UI for it.~~
Pulls out the States rendering into SharedUiMessage code into a function that is now recursive to properly render replies where the original message was edited, etc

RecyclingList has been cleaned up a tad, and extended to allow message rendering functions to return a list of more messages to be rendered indented before & after this one, which we use for replies now, and should work great for spaces soon!

Depends on pinned_events