### PR TITLE
Add a context menu with some message actions.

### DIFF
--- a/serif_android/src/main/java/xyz/room409/serif/serif_android/MainViewModel.kt
+++ b/serif_android/src/main/java/xyz/room409/serif/serif_android/MainViewModel.kt
@@ -61,6 +61,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
     fun sendMessage(message: String) = backgroundInvoke(inter.sendMessage(message))
+    fun sendReply(message: String, eventid: String) = backgroundInvoke(inter.sendReply(message, eventid))
+    fun sendEdit(message: String, eventid: String) = backgroundInvoke(inter.sendEdit(message, eventid))
+    fun sendReaction(reaction: String, eventid: String) = backgroundInvoke(inter.sendReaction(reaction, eventid))
     fun navigateToRoom(id: String) = backgroundInvoke(inter.navigateToRoom(id))
     fun exitRoom() = backgroundInvoke(inter.exitRoom())
     fun bumpWindow(id: String?) = backgroundInvoke(inter.bumpWindow(id))

--- a/serif_android/src/main/java/xyz/room409/serif/serif_android/conversation/ConversationFragment.kt
+++ b/serif_android/src/main/java/xyz/room409/serif/serif_android/conversation/ConversationFragment.kt
@@ -74,6 +74,9 @@ class ConversationFragment : Fragment() {
                         bumpWindowBase = { idx -> activityViewModel.bumpWindow(idx?.let { idx -> activityViewModel.messages.value.reversed().let { messages -> messages[min(idx, messages.size-1)].id } }); },
                         uiState = ConversationUiState(roomName, ourUserId, 0, messages.reversed()),
                         sendMessage = { message -> activityViewModel.sendMessage(message); },
+                        sendReply = { message, id -> activityViewModel.sendReply(message, id); },
+                        sendEdit = { message, id -> activityViewModel.sendEdit(message, id); },
+                        sendReaction = { message, id -> activityViewModel.sendReaction(message, id); },
                         navigateToRoom = { room -> activityViewModel.navigateToRoom(room); },
                         exitRoom = { activityViewModel.exitRoom(); },
                         navigateToProfile = { user ->

--- a/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/Conversation.kt
+++ b/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/Conversation.kt
@@ -87,7 +87,7 @@ import java.text.DateFormat
 import java.util.*
 
 abstract sealed class MessageSendType
-data class MstMessage(val _unused : String = "") : MessageSendType()
+class MstMessage() : MessageSendType()
 data class MstReply(val msg: SharedUiMessage): MessageSendType()
 data class MstEdit(val msg: SharedUiMessage): MessageSendType()
 data class MstReaction(val msg: SharedUiMessage): MessageSendType()
@@ -117,7 +117,7 @@ fun ConversationContent(
 ) {
     val scrollState = rememberLazyListState()
     val scope = rememberCoroutineScope()
-    var msg_type : MutableState<MessageSendType> = remember { mutableStateOf(MstMessage("")) }
+    var msg_type : MutableState<MessageSendType> = remember { mutableStateOf(MstMessage()) }
 
     // Helper lambda to decide which message type we are trying to send
     val determine_message_send_callback = { message : String ->
@@ -127,7 +127,7 @@ fun ConversationContent(
             is MstEdit -> { sendEdit(message, _mt.msg.id) }
             is MstReaction -> { sendReaction(message, _mt.msg.id) }
         }
-        msg_type.value = MstMessage("")
+        msg_type.value = MstMessage()
     }
 
     // Helper lambda to let popup change msg_type
@@ -205,7 +205,7 @@ fun MessageTypeContextBar(
 ) {
     Divider()
     Row(modifier = Modifier.fillMaxWidth()) {
-        Button( onClick = { updateMsgType(MstMessage("")) }) {
+        Button( onClick = { updateMsgType(MstMessage()) }) {
             Text("Cancel")
         }
         Box(modifier = Modifier.fillMaxWidth()) {

--- a/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/Conversation.kt
+++ b/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/Conversation.kt
@@ -427,6 +427,7 @@ fun Message(
             isLastMessageByAuthor = isLastMessageByAuthor,
             roomClicked = onRoomClick,
             authorClicked = onAuthorClick,
+            isUserMe = isUserMe,
             updateMsgType = updateMsgType,
             modifier = Modifier
                 .padding(end = 16.dp)
@@ -442,6 +443,7 @@ fun AuthorAndTextMessage(
     isLastMessageByAuthor: Boolean,
     roomClicked: (String) -> Unit,
     authorClicked: (String) -> Unit,
+    isUserMe: Boolean,
     updateMsgType: (MessageSendType) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -449,7 +451,7 @@ fun AuthorAndTextMessage(
         if (isLastMessageByAuthor) {
             AuthorNameTimestamp(msg)
         }
-        ChatItemBubble(msg, isFirstMessageByAuthor, roomClicked = roomClicked, authorClicked = authorClicked, updateMsgType = updateMsgType)
+        ChatItemBubble(msg, isFirstMessageByAuthor, roomClicked = roomClicked, authorClicked = authorClicked, updateMsgType = updateMsgType, isUserMe = isUserMe)
         if (isFirstMessageByAuthor) {
             // Last bubble before next author
             Spacer(modifier = Modifier.height(8.dp))
@@ -521,6 +523,7 @@ fun ChatItemBubble(
     roomClicked: (String) -> Unit,
     authorClicked: (String) -> Unit,
     updateMsgType: (MessageSendType) -> Unit,
+    isUserMe: Boolean
 ) {
 
     val backgroundBubbleColor =
@@ -541,10 +544,12 @@ fun ChatItemBubble(
         ) {
             Text("Reply")
         }
-        DropdownMenuItem(
-            onClick = { updateMsgType(MstEdit(message)); show_menu = false }
-        ) {
-            Text("Edit")
+        if(isUserMe) {
+            DropdownMenuItem(
+                onClick = { updateMsgType(MstEdit(message)); show_menu = false }
+            ) {
+                Text("Edit")
+            }
         }
         DropdownMenuItem(
             onClick = { updateMsgType(MstReaction(message)); show_menu = false }

--- a/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/Conversation.kt
+++ b/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/Conversation.kt
@@ -585,7 +585,6 @@ fun ChatItemBubble(
         modifier = Modifier.combinedClickable(
             onClick = {
                 println("NORMAL Press for message ${message.id}: ${message.message}")
-                show_menu = true
             },
             onDoubleClick = {
                 println("DOUBLE Press for message ${message.id}: ${message.message}")
@@ -593,6 +592,7 @@ fun ChatItemBubble(
             },
             onLongClick = {
                 println("LONG Press for message ${message.id}: ${message.message}")
+                show_menu = true
             }
         ).background(Color(0x22222222))
     )

--- a/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/Conversation.kt
+++ b/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/Conversation.kt
@@ -20,12 +20,16 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.background
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.paddingFrom
@@ -41,6 +45,8 @@ import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material.Button
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Divider
+import androidx.compose.material.DropdownMenu
+import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.Icon
 import androidx.compose.material.LocalContentAlpha
 import androidx.compose.material.LocalContentColor
@@ -80,6 +86,12 @@ import java.io.File
 import java.text.DateFormat
 import java.util.*
 
+abstract sealed class MessageSendType
+data class MstMessage(val _unused : String = "") : MessageSendType()
+data class MstReply(val msg: SharedUiMessage): MessageSendType()
+data class MstEdit(val msg: SharedUiMessage): MessageSendType()
+data class MstReaction(val msg: SharedUiMessage): MessageSendType()
+
 /**
  * Entry point for a conversation screen.
  *
@@ -93,6 +105,9 @@ fun ConversationContent(
     uiState: ConversationUiState,
     bumpWindowBase: (Int?) -> Unit,
     sendMessage: (String) -> Unit,
+    sendReply: (String,String) -> Unit = {_m, _s -> },
+    sendEdit: (String,String) -> Unit = {_m, _s -> },
+    sendReaction: (String,String) -> Unit = {_m, _s -> },
     navigateToRoom: (String) -> Unit,
     exitRoom: () -> Unit,
     navigateToProfile: (String) -> Unit,
@@ -102,6 +117,21 @@ fun ConversationContent(
 ) {
     val scrollState = rememberLazyListState()
     val scope = rememberCoroutineScope()
+    var msg_type : MutableState<MessageSendType> = remember { mutableStateOf(MstMessage("")) }
+
+    // Helper lambda to decide which message type we are trying to send
+    val determine_message_send_callback = { message : String ->
+        when(val _mt : MessageSendType = msg_type.value) {
+            is MstMessage -> { sendMessage(message) }
+            is MstReply -> { sendReply(message, _mt.msg.id) }
+            is MstEdit -> { sendEdit(message, _mt.msg.id) }
+            is MstReaction -> { sendReaction(message, _mt.msg.id) }
+        }
+        msg_type.value = MstMessage("")
+    }
+
+    // Helper lambda to let popup change msg_type
+    val change_message_type = { new_type : MessageSendType -> msg_type.value = new_type }
 
     Surface(modifier = modifier) {
         Box(modifier = Modifier.fillMaxSize()) {
@@ -115,12 +145,25 @@ fun ConversationContent(
                     bumpWindowBase = bumpWindowBase,
                     navigateToRoom = navigateToRoom,
                     navigateToProfile = navigateToProfile,
+                    updateMsgType = change_message_type,
                     modifier = Modifier.weight(1f),
                     scrollState = scrollState
                 )
+                when(val _mt : MessageSendType = msg_type.value) {
+                    is MstMessage -> {  }
+                    is MstReply -> {
+                        MessageTypeContextBar(text = "Replying to: ${_mt.msg.message}", updateMsgType = change_message_type)
+                    }
+                    is MstEdit -> {
+                        MessageTypeContextBar(text = "Editing: ${_mt.msg.message}", updateMsgType = change_message_type)
+                    }
+                    is MstReaction -> {
+                        MessageTypeContextBar(text = "Reacting to: ${_mt.msg.message}", updateMsgType = change_message_type)
+                    }
+                }
                 UserInput(
                     uiState.channelName,
-                    sendMessage,
+                    determine_message_send_callback,
                     {
                         scope.launch {
                             scrollState.scrollToItem(0)
@@ -151,6 +194,23 @@ fun ConversationContent(
                 println("LOOKING TO BUMP $it - ${scrollState.firstVisibleItemIndex} / ${scrollState.layoutInfo.totalItemsCount}")
                 bumpWindowBase(scrollState.firstVisibleItemIndex)
             }
+    }
+}
+
+@Composable
+fun MessageTypeContextBar(
+    text: String,
+    modifier: Modifier = Modifier,
+    updateMsgType: (MessageSendType) -> Unit,
+) {
+    Divider()
+    Row(modifier = Modifier.fillMaxWidth()) {
+        Button( onClick = { updateMsgType(MstMessage("")) }) {
+            Text("Cancel")
+        }
+        Box(modifier = Modifier.fillMaxWidth()) {
+            Text(text)
+        }
     }
 }
 
@@ -227,6 +287,7 @@ fun Messages(
     bumpWindowBase: (Int?) -> Unit,
     navigateToRoom: (String) -> Unit,
     navigateToProfile: (String) -> Unit,
+    updateMsgType: (MessageSendType) -> Unit,
     scrollState: LazyListState,
     modifier: Modifier = Modifier
 ) {
@@ -279,6 +340,7 @@ fun Messages(
                     Message(
                         onRoomClick = navigateToRoom,
                         onAuthorClick = { name -> navigateToProfile(name) },
+                        updateMsgType = updateMsgType,
                         msg = content,
                         isUserMe = content.sender == ourUserId,
                         isFirstMessageByAuthor = isFirstMessageByAuthor,
@@ -320,6 +382,7 @@ fun Messages(
 fun Message(
     onRoomClick: (String) -> Unit,
     onAuthorClick: (String) -> Unit,
+    updateMsgType: (MessageSendType) -> Unit,
     msg: SharedUiMessage,
     isUserMe: Boolean,
     isFirstMessageByAuthor: Boolean,
@@ -364,6 +427,7 @@ fun Message(
             isLastMessageByAuthor = isLastMessageByAuthor,
             roomClicked = onRoomClick,
             authorClicked = onAuthorClick,
+            updateMsgType = updateMsgType,
             modifier = Modifier
                 .padding(end = 16.dp)
                 .weight(1f)
@@ -378,13 +442,14 @@ fun AuthorAndTextMessage(
     isLastMessageByAuthor: Boolean,
     roomClicked: (String) -> Unit,
     authorClicked: (String) -> Unit,
+    updateMsgType: (MessageSendType) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(modifier = modifier) {
         if (isLastMessageByAuthor) {
             AuthorNameTimestamp(msg)
         }
-        ChatItemBubble(msg, isFirstMessageByAuthor, roomClicked = roomClicked, authorClicked = authorClicked)
+        ChatItemBubble(msg, isFirstMessageByAuthor, roomClicked = roomClicked, authorClicked = authorClicked, updateMsgType = updateMsgType)
         if (isFirstMessageByAuthor) {
             // Last bubble before next author
             Spacer(modifier = Modifier.height(8.dp))
@@ -454,7 +519,8 @@ fun ChatItemBubble(
     message: SharedUiMessage,
     lastMessageByAuthor: Boolean,
     roomClicked: (String) -> Unit,
-    authorClicked: (String) -> Unit
+    authorClicked: (String) -> Unit,
+    updateMsgType: (MessageSendType) -> Unit,
 ) {
 
     val backgroundBubbleColor =
@@ -465,27 +531,88 @@ fun ChatItemBubble(
             //MaterialTheme.colors.elevatedSurface(2.dp)
         }
 
-    val bubbleShape = if (lastMessageByAuthor) LastChatBubbleShape else ChatBubbleShape
-    Column {
-        Surface(color = backgroundBubbleColor, shape = bubbleShape) {
-            ClickableMessage(
-                message = message,
-                roomClicked = roomClicked,
-                authorClicked = authorClicked
-            )
+    var show_menu by remember { mutableStateOf(false) }
+    DropdownMenu(
+        expanded = show_menu,
+        onDismissRequest = {show_menu = false}
+    ) {
+        DropdownMenuItem(
+            onClick = { updateMsgType(MstReply(message)); show_menu = false }
+        ) {
+            Text("Reply")
         }
-        if (message is SharedUiImgMessage) {
-            Spacer(modifier = Modifier.height(4.dp))
+        DropdownMenuItem(
+            onClick = { updateMsgType(MstEdit(message)); show_menu = false }
+        ) {
+            Text("Edit")
+        }
+        DropdownMenuItem(
+            onClick = { updateMsgType(MstReaction(message)); show_menu = false }
+        ) {
+            Text("Reaction")
+        }
+        //TODO(marcus): Implement deletion logic
+        DropdownMenuItem(
+            onClick = { println("Deleting Message"); show_menu = false }
+        ) {
+            Text("Delete")
+        }
+        Divider()
+        //TODO(marcus): Implement show source logic
+        DropdownMenuItem(
+            onClick = {
+                println("Viewing Message Source")
+                show_menu = false
+            }
+        ) {
+            Text("View Source")
+        }
+    }
+
+    /* NOTE(marcus): The API is still being worked on for clickable callbacks,
+     * in particular right click handling which only really makes sense on desktop.
+     * For now we can just use some of the click events provided for combinedClickable,
+     * and we can add right click support later.
+     */
+    val bubbleShape = if (lastMessageByAuthor) LastChatBubbleShape else ChatBubbleShape
+    @OptIn(ExperimentalFoundationApi::class)
+    Box(
+        modifier = Modifier.combinedClickable(
+            onClick = {
+                println("NORMAL Press for message ${message.id}: ${message.message}")
+                show_menu = true
+            },
+            onDoubleClick = {
+                println("DOUBLE Press for message ${message.id}: ${message.message}")
+                show_menu = true
+            },
+            onLongClick = {
+                println("LONG Press for message ${message.id}: ${message.message}")
+            }
+        ).background(Color(0x22222222))
+    )
+    {
+        Column {
             Surface(color = backgroundBubbleColor, shape = bubbleShape) {
-                Spacer(modifier = Modifier.width(74.dp).height(74.dp))
-                /*
-                Image(
-                    painter = rememberImagePainter(File(message.url)),
-                    contentScale = ContentScale.Fit,
-                    modifier = Modifier.size(160.dp),
-                    contentDescription = message.message
+                ClickableMessage(
+                    message = message,
+                    roomClicked = roomClicked,
+                    authorClicked = authorClicked
                 )
-                */
+            }
+            if (message is SharedUiImgMessage) {
+                Spacer(modifier = Modifier.height(4.dp))
+                Surface(color = backgroundBubbleColor, shape = bubbleShape) {
+                    Spacer(modifier = Modifier.width(74.dp).height(74.dp))
+                    /*
+                    Image(
+                        painter = rememberImagePainter(File(message.url)),
+                        contentScale = ContentScale.Fit,
+                        modifier = Modifier.size(160.dp),
+                        contentDescription = message.message
+                    )
+                    */
+                }
             }
         }
     }

--- a/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/MatrixInterface.kt
+++ b/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/MatrixInterface.kt
@@ -94,6 +94,24 @@ class MatrixInterface {
             }
         }
     }
+    fun sendReply(message: String, eventid: String): () -> Unit {
+        return { ->
+            val _m = m
+            if (_m is MatrixChatRoom) { _m.sendReply(message, eventid) }
+        }
+    }
+    fun sendEdit(message: String, eventid: String): () -> Unit {
+        return { ->
+            val _m = m
+            if (_m is MatrixChatRoom) { _m.sendEdit(message, eventid) }
+        }
+    }
+    fun sendReaction(message: String, eventid: String): () -> Unit {
+        return { ->
+            val _m = m
+            if (_m is MatrixChatRoom) { _m.sendReaction(message, eventid) }
+        }
+    }
     fun navigateToRoom(id: String) = pushDo(Action.NavigateToRoom(id))
     fun exitRoom() = pushDo(Action.ExitRoom())
     fun bumpWindow(id: String?) = pushDo(Action.Refresh(50, id, 50))

--- a/serif_compose_desktop/src/main/kotlin/main.kt
+++ b/serif_compose_desktop/src/main/kotlin/main.kt
@@ -49,6 +49,9 @@ class FakeViewModel {
         }
     }
     fun sendMessage(message: String) = backgroundInvoke(inter.sendMessage(message))
+    fun sendReply(message: String, eventid: String) = backgroundInvoke(inter.sendReply(message, eventid))
+    fun sendEdit(message: String, eventid: String) = backgroundInvoke(inter.sendEdit(message, eventid))
+    fun sendReaction(reaction: String, eventid: String) = backgroundInvoke(inter.sendReaction(reaction, eventid))
     fun navigateToRoom(id: String) = backgroundInvoke(inter.navigateToRoom(id))
     fun exitRoom() = backgroundInvoke(inter.exitRoom())
     fun bumpWindow(id: String?) = backgroundInvoke(inter.bumpWindow(id))
@@ -77,6 +80,9 @@ fun main() = application {
                 bumpWindowBase = { idx -> fakeViewModel.bumpWindow(idx?.let { idx -> fakeViewModel.messages.value.reversed().let { messages -> messages[min(idx, messages.size-1)].id } }); },
                 uiState = ConversationUiState(fakeViewModel.roomName.value, fakeViewModel.ourUserId.value, 0, fakeViewModel.messages.value.reversed()),
                 sendMessage = { message -> fakeViewModel.sendMessage(message); },
+                sendReply = { message, id -> fakeViewModel.sendReply(message, id); },
+                sendEdit = { message, id -> fakeViewModel.sendEdit(message, id); },
+                sendReaction = { message, id -> fakeViewModel.sendReaction(message, id); },
                 navigateToRoom = { room -> fakeViewModel.navigateToRoom(room); },
                 exitRoom = { fakeViewModel.exitRoom(); },
                 navigateToProfile = { user -> println("clicked on user $user"); },


### PR DESCRIPTION
Adds menu options for reply, edit, and reaction, as well as placeholder
entries for delete and show message source. Also enables replies, edits,
and reactions to be sent out. Adds an indicator above the text entry for
showing what type of message is being created for more involved message
types.

This does not cover displaying replies or reactions in the conversation view, only sending them.

Fixes #117 #114 and #130 