### PR TITLE
Add audio message support on desktop.

### DIFF
--- a/serif_compose/build.gradle.kts
+++ b/serif_compose/build.gradle.kts
@@ -33,7 +33,6 @@ kotlin {
         }
         val jvmMain by getting {
             dependencies {
-                implementation("uk.co.caprica:vlcj:4.7.1")
             }
         }
     }

--- a/serif_compose/build.gradle.kts
+++ b/serif_compose/build.gradle.kts
@@ -4,7 +4,6 @@ import org.jetbrains.compose.compose
 plugins {
     id("com.android.library")
     kotlin("multiplatform")
-    //id("org.jetbrains.compose") version "1.0.0-alpha1"
     id("org.jetbrains.compose") version "1.0.0-beta5"
 }
 
@@ -34,6 +33,7 @@ kotlin {
         }
         val jvmMain by getting {
             dependencies {
+                implementation("uk.co.caprica:vlcj:4.7.1")
             }
         }
     }

--- a/serif_compose/src/androidMain/kotlin/xyz/room409/serif/serif_compose/UiPlatform.kt
+++ b/serif_compose/src/androidMain/kotlin/xyz/room409/serif/serif_compose/UiPlatform.kt
@@ -42,6 +42,7 @@ actual object UiPlatform {
 actual object AudioPlayer {
     actual fun loadAudio(audio_url: String) { }
     actual fun play() { }
+    actual fun stop() { }
     actual fun isPlaying(): Boolean { return false }
     actual fun getActiveUrl(): String { return "" }
 }

--- a/serif_compose/src/androidMain/kotlin/xyz/room409/serif/serif_compose/UiPlatform.kt
+++ b/serif_compose/src/androidMain/kotlin/xyz/room409/serif/serif_compose/UiPlatform.kt
@@ -43,7 +43,7 @@ actual object AudioPlayer {
     actual fun loadAudio(audio_url: String) { }
     actual fun play() { }
     actual fun stop() { }
-    actual fun isPlaying(): Boolean { return false }
+    actual fun isPlaying(cb: (Boolean) -> Unit) { }
     actual fun getActiveUrl(): String { return "" }
 }
 actual fun ShowSaveDialog(filename: String, save_location_callback: (String)->Unit): Unit {

--- a/serif_compose/src/androidMain/kotlin/xyz/room409/serif/serif_compose/UiPlatform.kt
+++ b/serif_compose/src/androidMain/kotlin/xyz/room409/serif/serif_compose/UiPlatform.kt
@@ -38,3 +38,10 @@ actual object UiPlatform {
         }
     }
 }
+
+actual object AudioPlayer {
+    actual fun loadAudio(audio_url: String) { }
+    actual fun play() { }
+    actual fun isPlaying(): Boolean { return false }
+    actual fun getActiveUrl(): String { return "" }
+}

--- a/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/Conversation.kt
+++ b/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/Conversation.kt
@@ -85,6 +85,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import xyz.room409.serif.serif_shared.SharedUiLocationMessage
 import xyz.room409.serif.serif_shared.SharedUiImgMessage
+import xyz.room409.serif.serif_shared.SharedUiAudioMessage
 import xyz.room409.serif.serif_shared.SharedUiMessage
 import xyz.room409.serif.serif_shared.SharedUiRoom
 import java.io.File
@@ -758,6 +759,25 @@ fun ChatItemBubble(
                             }
                         }
                     )
+                }
+            } else if (message is SharedUiAudioMessage) {
+                val audio_title = message.message
+                val audio_url = message.url
+                var isPlaying by remember { mutableStateOf((AudioPlayer.isPlaying() && (audio_url == AudioPlayer.getActiveUrl()))) }
+                var msg_button_text = mutableStateOf(if(isPlaying) { "Pause" } else { "Play" })
+                Spacer(modifier = Modifier.height(4.dp))
+                Surface(color = backgroundBubbleColor, shape = bubbleShape) {
+                    Column(modifier = Modifier.width(IntrinsicSize.Max)) {
+                        Text("${audio_title}\n${audio_url}")
+                        Button(onClick = {
+                            AudioPlayer.loadAudio(audio_url)
+                            AudioPlayer.play()
+                            isPlaying = !isPlaying
+                            msg_button_text.value = if(isPlaying) { "Pause" } else { "Play" }
+                        }) {
+                            Text(msg_button_text.value)
+                        }
+                    }
                 }
             } else {
                 Surface(color = backgroundBubbleColor, shape = bubbleShape) {

--- a/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/Conversation.kt
+++ b/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/Conversation.kt
@@ -773,8 +773,13 @@ fun ChatItemBubble(
             } else if (message is SharedUiAudioMessage) {
                 val audio_title = message.message
                 val audio_url = message.url
-                var isPlaying by remember { mutableStateOf((AudioPlayer.isPlaying() && (audio_url == AudioPlayer.getActiveUrl()))) }
-                var msg_button_text = mutableStateOf(if(isPlaying) { "Pause" } else { "Play" })
+                var isPlaying by remember { mutableStateOf(false); }
+                if(audio_url == AudioPlayer.getActiveUrl()) {
+                    AudioPlayer.isPlaying({ playing : Boolean -> isPlaying = playing; })
+                } else {
+                    isPlaying = false;
+                }
+                var msg_button_text = if(isPlaying) { "Pause" } else { "Play" }
                 Spacer(modifier = Modifier.height(4.dp))
                 Surface(color = backgroundBubbleColor, shape = bubbleShape) {
                     Column(modifier = Modifier.width(IntrinsicSize.Max)) {
@@ -783,9 +788,8 @@ fun ChatItemBubble(
                             AudioPlayer.loadAudio(audio_url)
                             AudioPlayer.play()
                             isPlaying = !isPlaying
-                            msg_button_text.value = if(isPlaying) { "Pause" } else { "Play" }
                         }) {
-                            Text(msg_button_text.value)
+                            Text(msg_button_text)
                         }
                     }
                 }

--- a/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/Conversation.kt
+++ b/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/Conversation.kt
@@ -126,7 +126,7 @@ fun ConversationContent(
     val sendRedaction = { eventid: String -> runInViewModel { inter -> inter.sendRedaction(eventid) } }
     val saveMediaToPath = { path: String, url: String -> runInViewModel { inter -> inter.saveMediaToPath(path, url) } }
     val navigateToRoom = { id: String -> runInViewModel { inter -> inter.navigateToRoom(id) } }
-    val exitRoom = { -> runInViewModel { inter -> inter.exitRoom() } }
+    val exitRoom = { -> AudioPlayer.stop(); runInViewModel { inter -> inter.exitRoom() } }
 
     val scrollState = rememberLazyListState()
     val scope = rememberCoroutineScope()

--- a/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/UiPlatform.kt
+++ b/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/UiPlatform.kt
@@ -11,7 +11,7 @@ expect object AudioPlayer {
     fun loadAudio(audio_url: String)
     fun play()
     fun stop()
-    fun isPlaying(): Boolean
+    fun isPlaying(cb: (Boolean) -> Unit)
     fun getActiveUrl(): String
 }
 

--- a/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/UiPlatform.kt
+++ b/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/UiPlatform.kt
@@ -10,6 +10,7 @@ expect object UiPlatform {
 expect object AudioPlayer {
     fun loadAudio(audio_url: String)
     fun play()
+    fun stop()
     fun isPlaying(): Boolean
     fun getActiveUrl(): String
 }

--- a/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/UiPlatform.kt
+++ b/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/UiPlatform.kt
@@ -7,5 +7,12 @@ expect object UiPlatform {
     fun getOpenUrl(): ((url: String) -> Unit)?
 }
 
+expect object AudioPlayer {
+    fun loadAudio(audio_url: String)
+    fun play()
+    fun isPlaying(): Boolean
+    fun getActiveUrl(): String
+}
+
 @Composable expect fun DeletionDialog(message: SharedUiMessage, sendRedaction: (String)->Unit, close_deletion_dialog: () -> Unit): Unit
 

--- a/serif_compose/src/jvmMain/kotlin/xyz/room409/serif/serif_compose/UiPlatform.kt
+++ b/serif_compose/src/jvmMain/kotlin/xyz/room409/serif/serif_compose/UiPlatform.kt
@@ -12,6 +12,8 @@ import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.rememberDialogState
 import java.io.BufferedReader
 import java.io.InputStreamReader
+import uk.co.caprica.vlcj.player.base.MediaPlayer;
+import uk.co.caprica.vlcj.player.component.AudioPlayerComponent;
 import kotlin.concurrent.thread
 import xyz.room409.serif.serif_shared.SharedUiMessage
 
@@ -51,27 +53,52 @@ actual object UiPlatform {
 }
 
 @Composable actual fun DeletionDialog(message: SharedUiMessage, sendRedaction: (String)->Unit, close_deletion_dialog: () -> Unit): Unit {
-        var reason by remember { mutableStateOf("") }
-        Dialog(
-            onCloseRequest = { close_deletion_dialog(); reason = "" },
-            state = rememberDialogState(position = WindowPosition(Alignment.Center))
-        ) {
-                Column() {
-                    Text("Deleting: ${message.message}")
-                    Text("Reason:")
-                    TextField(
-                        value = reason,
-                        onValueChange = { reason = it })
-                    Row() {
-                        Button(onClick = { sendRedaction(message.id); close_deletion_dialog(); reason = "" }) {
-                            Text("Confirm")
-                        }
-                        Button(onClick = { close_deletion_dialog(); reason = "" }) {
-                            Text("Cancel")
-                        }
+    var reason by remember { mutableStateOf("") }
+    Dialog(
+        onCloseRequest = { close_deletion_dialog(); reason = "" },
+        state = rememberDialogState(position = WindowPosition(Alignment.Center))
+    ) {
+            Column() {
+                Text("Deleting: ${message.message}")
+                Text("Reason:")
+                TextField(
+                    value = reason,
+                    onValueChange = { reason = it })
+                Row() {
+                    Button(onClick = { sendRedaction(message.id); close_deletion_dialog(); reason = "" }) {
+                        Text("Confirm")
+                    }
+                    Button(onClick = { close_deletion_dialog(); reason = "" }) {
+                        Text("Cancel")
                     }
                 }
             }
+        }
+}
+
+actual object AudioPlayer {
+    var url = ""
+    var vp_audioPlayer = AudioPlayerComponent()
+    actual fun loadAudio(audio_url: String) {
+        if(audio_url != url) {
+            //Load audio data
+            vp_audioPlayer.mediaPlayer().media().prepare(audio_url)
+
+            //Update URL
+            url = audio_url
+        }
     }
-/*
-    */
+    actual fun play() {
+        if(isPlaying()) {
+            vp_audioPlayer.mediaPlayer().controls().pause()
+        } else {
+            vp_audioPlayer.mediaPlayer().controls().play()
+        }
+    }
+    actual fun isPlaying(): Boolean {
+        return vp_audioPlayer.mediaPlayer().status().isPlaying()
+    }
+    actual fun getActiveUrl(): String {
+        return url
+    }
+}

--- a/serif_compose/src/jvmMain/kotlin/xyz/room409/serif/serif_compose/UiPlatform.kt
+++ b/serif_compose/src/jvmMain/kotlin/xyz/room409/serif/serif_compose/UiPlatform.kt
@@ -94,6 +94,9 @@ actual object AudioPlayer {
     actual fun play() {
         send_command("pause")
     }
+    actual fun stop() {
+        send_command("stop")
+    }
     actual fun isPlaying(): Boolean {
         if(audioPlayer_proc != null) {
             val writer = BufferedWriter(OutputStreamWriter(audioPlayer_proc?.getOutputStream()))


### PR DESCRIPTION
Fix for #122 
Only tested on linux desktop, uses the VLCJ library which makes us have a dependency on VLC for audio playing but it was the only solution I could find that didn't cause playback of WAV and MP3s to cut short or the speaker to pop when the audio is first loaded. We could also potentially use VLC for video playback for desktop too so this isn't too bad of a situation. Android has its own media playback API that we will need to learn how to use.