### PR TITLE
Support file type messages and support downloading for desktop.

### DIFF
--- a/serif_compose/src/androidMain/kotlin/xyz/room409/serif/serif_compose/UiPlatform.kt
+++ b/serif_compose/src/androidMain/kotlin/xyz/room409/serif/serif_compose/UiPlatform.kt
@@ -38,3 +38,8 @@ actual object UiPlatform {
         }
     }
 }
+
+actual fun ShowSaveDialog(filename: String, save_location_callback: (String)->Unit): Unit {
+    //TODO: implement this with native android file chooser
+    return
+}

--- a/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/Conversation.kt
+++ b/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/Conversation.kt
@@ -85,6 +85,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import xyz.room409.serif.serif_shared.SharedUiLocationMessage
 import xyz.room409.serif.serif_shared.SharedUiImgMessage
+import xyz.room409.serif.serif_shared.SharedUiFileMessage
 import xyz.room409.serif.serif_shared.SharedUiMessage
 import xyz.room409.serif.serif_shared.SharedUiRoom
 import java.io.File
@@ -122,6 +123,7 @@ fun ConversationContent(
     val sendReaction = { reaction: String, eventid: String -> runInViewModel { inter -> inter.sendReaction(reaction, eventid) } }
     val togglePinnedEvent = { event_id: String -> runInViewModel { inter -> inter.togglePinnedEvent(event_id) } }
     val sendRedaction = { eventid: String -> runInViewModel { inter -> inter.sendRedaction(eventid) } }
+    val saveMediaToPath = { path: String, url: String -> runInViewModel { inter -> inter.saveMediaToPath(path, url) } }
     val navigateToRoom = { id: String -> runInViewModel { inter -> inter.navigateToRoom(id) } }
     val exitRoom = { -> runInViewModel { inter -> inter.exitRoom() } }
 
@@ -158,6 +160,7 @@ fun ConversationContent(
                     updateMsgType = change_message_type,
                     sendRedaction = sendRedaction,
                     sendReaction = sendReaction,
+                    saveMediaToPath = saveMediaToPath,
                     sendMessage = sendMessage,
                     togglePinnedEvent = togglePinnedEvent,
                     pinned = uiState.pinned,
@@ -305,6 +308,7 @@ fun Messages(
     updateMsgType: (MessageSendType) -> Unit,
     sendRedaction: (String) -> Unit,
     sendReaction: (String,String) -> Unit,
+    saveMediaToPath: (String,String) -> Unit,
     sendMessage: (String) -> Unit,
     togglePinnedEvent: (String) -> Unit,
     pinned: List<String>,
@@ -363,6 +367,7 @@ fun Messages(
                         updateMsgType = updateMsgType,
                         sendRedaction = sendRedaction,
                         sendReaction = sendReaction,
+                        saveMediaToPath = saveMediaToPath,
                         sendMessage = sendMessage,
                         togglePinnedEvent = togglePinnedEvent,
                         pinned = pinned,
@@ -411,6 +416,7 @@ fun Message(
     updateMsgType: (MessageSendType) -> Unit,
     sendRedaction: (String) -> Unit,
     sendReaction: (String,String) -> Unit,
+    saveMediaToPath: (String,String) -> Unit,
     sendMessage: (String) -> Unit,
     togglePinnedEvent: (String) -> Unit,
     pinned: List<String>,
@@ -464,6 +470,7 @@ fun Message(
             sendRedaction = sendRedaction,
             ourUserId = ourUserId,
             sendReaction = sendReaction,
+            saveMediaToPath = saveMediaToPath,
             sendMessage = sendMessage,
             togglePinnedEvent = togglePinnedEvent,
             pinned = pinned,
@@ -486,6 +493,7 @@ fun AuthorAndTextMessage(
     sendRedaction: (String) -> Unit,
     ourUserId: String,
     sendReaction: (String,String) -> Unit,
+    saveMediaToPath: (String,String) -> Unit,
     sendMessage: (String) -> Unit,
     togglePinnedEvent: (String) -> Unit,
     pinned: List<String>,
@@ -501,6 +509,7 @@ fun AuthorAndTextMessage(
                 authorClicked = authorClicked,
                 updateMsgType = updateMsgType,
                 sendRedaction = sendRedaction,
+                saveMediaToPath = saveMediaToPath,
                 togglePinnedEvent = togglePinnedEvent,
                 pinned = pinned,
                 isUserMe = isUserMe,
@@ -631,6 +640,7 @@ fun ChatItemBubble(
     sendMessage: (String) -> Unit,
     pinned: List<String>,
     sendRedaction: (String) -> Unit,
+    saveMediaToPath: (String,String) -> Unit,
     isUserMe: Boolean
 ) {
 
@@ -758,6 +768,23 @@ fun ChatItemBubble(
                             }
                         }
                     )
+                }
+            } else if (message is SharedUiFileMessage) {
+                Spacer(modifier = Modifier.height(4.dp))
+                Surface(color = backgroundBubbleColor, shape = bubbleShape) {
+                    Column(modifier = Modifier.width(IntrinsicSize.Max)) {
+                        val filename =
+                            if(message.filename != "") { message.filename } else { message.message }
+                        Text("$filename ${message.mimetype}")
+                        Button(onClick = {
+                            val callback = { user_file_path: String ->
+                                try { saveMediaToPath(user_file_path, message.url) } catch (e: Exception) { println("Couldn't save media, $e") }
+                            }
+                            ShowSaveDialog(filename, callback)
+                        }) {
+                            Text("Download")
+                        }
+                    }
                 }
             } else {
                 Surface(color = backgroundBubbleColor, shape = bubbleShape) {

--- a/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/MatrixInterface.kt
+++ b/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/MatrixInterface.kt
@@ -127,6 +127,12 @@ class MatrixInterface {
             if (_m is MatrixChatRoom) { _m.sendRedaction(msgid) }
         }
     }
+    fun saveMediaToPath(path: String, url: String): () -> Unit {
+        return { ->
+            val _m = m
+            if (_m is MatrixChatRoom) { _m.saveMediaToPath(path,url) }
+        }
+    }
     fun navigateToRoom(id: String) = pushDo(Action.NavigateToRoom(id))
     fun exitRoom() = pushDo(Action.ExitRoom())
     fun bumpWindow(id: String?) = pushDo(Action.Refresh(50, id, 50))

--- a/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/UiPlatform.kt
+++ b/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/UiPlatform.kt
@@ -9,3 +9,4 @@ expect object UiPlatform {
 
 @Composable expect fun DeletionDialog(message: SharedUiMessage, sendRedaction: (String)->Unit, close_deletion_dialog: () -> Unit): Unit
 
+expect fun ShowSaveDialog(filename: String, save_location_callback: (String)->Unit): Unit

--- a/serif_compose/src/jvmMain/kotlin/xyz/room409/serif/serif_compose/UiPlatform.kt
+++ b/serif_compose/src/jvmMain/kotlin/xyz/room409/serif/serif_compose/UiPlatform.kt
@@ -12,6 +12,8 @@ import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.rememberDialogState
 import java.io.BufferedReader
 import java.io.InputStreamReader
+import java.io.File
+import javax.swing.*
 import kotlin.concurrent.thread
 import xyz.room409.serif.serif_shared.SharedUiMessage
 
@@ -73,5 +75,13 @@ actual object UiPlatform {
                 }
             }
     }
-/*
-    */
+
+actual fun ShowSaveDialog(filename: String, save_location_callback: (String)->Unit): Unit {
+    val chooser = JFileChooser()
+    chooser.setSelectedFile(File(filename))
+    val ret = chooser.showSaveDialog(null)
+    if(ret == JFileChooser.APPROVE_OPTION) {
+        val user_file_path = chooser.getSelectedFile().getAbsolutePath()
+        save_location_callback(user_file_path)
+    }
+}


### PR DESCRIPTION
Fix for #115 
Currently an empty implementation for android. Android will have native file dialogs we can use and desktop currently uses the swing file chooser dialog but it should be rewritten as a "native" screen with actual compose elements in a later PR.