### PR TITLE
Room metadata Compose

### DIFF
--- a/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/Conversation.kt
+++ b/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/Conversation.kt
@@ -124,7 +124,7 @@ fun ConversationContent(
     val sendRedaction = { eventid: String -> runInViewModel { inter -> inter.sendRedaction(eventid) } }
     val navigateToRoom = { id: String -> runInViewModel { inter -> inter.navigateToRoom(id) } }
     val exitRoom = { -> runInViewModel { inter -> inter.exitRoom() } }
-    val onRoomSettingsPressed = { -> }
+    val onRoomSettingsPressed = { -> runInViewModel { inter -> inter.navigateToRoomInfo() } }
 
     val scrollState = rememberLazyListState()
     val scope = rememberCoroutineScope()
@@ -288,7 +288,12 @@ fun ChannelNameBar(
                     DropdownMenuItem(
                         onClick = { show_menu = false }
                     ) {
-                        Text("Invite")
+                        Text("Invite (Unimplemented)")
+                    }
+                    DropdownMenuItem(
+                        onClick = { show_menu = false }
+                    ) {
+                        Text("Leave Room (Unimplemented)")
                     }
                 }
                 /*

--- a/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/Conversation.kt
+++ b/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/Conversation.kt
@@ -124,6 +124,7 @@ fun ConversationContent(
     val sendRedaction = { eventid: String -> runInViewModel { inter -> inter.sendRedaction(eventid) } }
     val navigateToRoom = { id: String -> runInViewModel { inter -> inter.navigateToRoom(id) } }
     val exitRoom = { -> runInViewModel { inter -> inter.exitRoom() } }
+    val onRoomSettingsPressed = { -> }
 
     val scrollState = rememberLazyListState()
     val scope = rememberCoroutineScope()
@@ -193,6 +194,7 @@ fun ConversationContent(
                 channelMembers = uiState.channelMembers,
                 onNavIconPressed = onNavIconPressed,
                 onBackPressed = exitRoom,
+                onRoomSettingsPressed = onRoomSettingsPressed
                 // Use statusBarsPadding() to move the app bar content below the status bar
                 //modifier = Modifier.statusBarsPadding(),
             )
@@ -235,12 +237,14 @@ fun ChannelNameBar(
     channelMembers: Int,
     modifier: Modifier = Modifier,
     onNavIconPressed: () -> Unit = { },
-    onBackPressed: () -> Unit = { }
+    onBackPressed: () -> Unit = { },
+    onRoomSettingsPressed: () -> Unit = { }
 ) {
     var functionalityNotAvailablePopupShown by remember { mutableStateOf(false) }
     if (functionalityNotAvailablePopupShown) {
         //FunctionalityNotAvailablePopup { functionalityNotAvailablePopupShown = false }
     }
+    var show_menu by remember { mutableStateOf(false) }
     JetchatAppBar(
         modifier = modifier,
         onNavIconPressed = onNavIconPressed,
@@ -267,6 +271,25 @@ fun ChannelNameBar(
             CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
                 Button( onClick = onBackPressed) {
                     Text("Back")
+                }
+                Button(onClick = { -> show_menu = true }) {
+                    Text("...")
+                }
+                DropdownMenu(
+                    expanded = show_menu,
+                    onDismissRequest = {show_menu = false}
+                ) {
+                    DropdownMenuItem(
+                        onClick = { onRoomSettingsPressed(); show_menu = false }
+                    ) {
+                        Text("Settings")
+                    }
+                    //TODO: Implement Room Invitations
+                    DropdownMenuItem(
+                        onClick = { show_menu = false }
+                    ) {
+                        Text("Invite")
+                    }
                 }
                 /*
                 // Search icon

--- a/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/ConversationUiState.kt
+++ b/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/ConversationUiState.kt
@@ -24,7 +24,9 @@ class ConversationUiState(
     val ourUserId: String,
     val channelMembers: Int,
     initialMessages: List<SharedUiMessage>,
-    val pinned: List<String>
+    val pinned: List<String>,
+    val members: List<String> = listOf(),
+    val roomTopic: String = ""
 ) {
     private val _messages: MutableList<SharedUiMessage> =
         mutableStateListOf(*initialMessages.toTypedArray())

--- a/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/ConversationUiState.kt
+++ b/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/ConversationUiState.kt
@@ -26,7 +26,8 @@ class ConversationUiState(
     initialMessages: List<SharedUiMessage>,
     val pinned: List<String>,
     val members: List<String> = listOf(),
-    val roomTopic: String = ""
+    val roomTopic: String = "",
+    val roomAvatarUrl: String = ""
 ) {
     private val _messages: MutableList<SharedUiMessage> =
         mutableStateListOf(*initialMessages.toTypedArray())

--- a/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/MatrixInterface.kt
+++ b/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/MatrixInterface.kt
@@ -35,8 +35,10 @@ class MatrixInterface {
     val messages: MutableState<List<SharedUiMessage>> = mutableStateOf(listOf())
     val roomPath: MutableState<List<String>> = mutableStateOf(listOf())
     val roomName: MutableState<String> = mutableStateOf("<>")
+    val roomTopic: MutableState<String> = mutableStateOf("")
     val sessions: MutableState<List<String>> = mutableStateOf(listOf())
     val pinned: MutableState<List<String>> = mutableStateOf(listOf())
+    val members: MutableState<List<String>> = mutableStateOf(listOf())
     val lock = ReentrantLock()
     val actions: MutableList<Action> = mutableListOf()
     var already_a_background_thread_running = false
@@ -51,16 +53,20 @@ class MatrixInterface {
                 messages.value = listOf()
                 roomPath.value = listOf()
                 roomName.value = "Login"
+                roomTopic.value = ""
                 sessions.value = _m.getSessions()
                 pinned.value = listOf()
+                members.value = listOf()
             }
             is MatrixChatRoom -> {
                 messages.value = _m.messages
                 roomPath.value = _m.room_ids
                 roomName.value = _m.name
+                roomTopic.value = _m.roomTopic
                 ourUserId.value = _m.username
                 sessions.value = listOf()
                 pinned.value = _m.pinned
+                members.value = _m.members
             }
         }
     }
@@ -136,7 +142,20 @@ class MatrixInterface {
             if (_m is MatrixChatRoom) { _m.sendRedaction(msgid) }
         }
     }
+    fun setRoomTopic(topic: String): () -> Unit {
+        return { ->
+            val _m = m
+            if (_m is MatrixChatRoom) { _m.setRoomTopic(topic) }
+        }
+    }
+    fun setRoomName(name: String): () -> Unit {
+        return { ->
+            val _m = m
+            if (_m is MatrixChatRoom) { _m.setRoomName(name) }
+        }
+    }
     fun navigateToRoom(id: String) = pushDo(Action.NavigateToRoom(id))
+    fun navigateToRoomInfo() = pushDo(Action.NavigateToRoomInfo())
     fun exitRoom() = pushDo(Action.ExitRoom())
     fun bumpWindow(id: String?) = pushDo(Action.Refresh(50, id, 50))
 
@@ -146,6 +165,7 @@ class MatrixInterface {
         try {
             when (_a) {
                 is Action.NavigateToRoom -> { println("clearing actiosn b/c NavigateToRoom"); actions.clear(); }
+                is Action.NavigateToRoomInfo -> { println("clearing actions b/c NavigateToRoomInfo"); actions.clear(); }
                 is Action.ExitRoom -> { println("clearing actiosn b/c ExitRoom"); actions.clear(); }
                 is Action.Refresh -> {
                     if (actions.size != 0) {
@@ -191,9 +211,13 @@ class MatrixInterface {
             is Action.ExitRoom -> {
                 when (val _m = m) {
                     is MatrixChatRoom -> {
-                        m = _m.exitRoom()
-                        refresh()
-                        if(m is MatrixLogin) { uistate.value = UiLogin() }
+                        if(uistate.value is UiRoomInfo) {
+                            uistate.value = UiChatRoom()
+                        } else {
+                            m = _m.exitRoom()
+                            refresh()
+                            if(m is MatrixLogin) { uistate.value = UiLogin() }
+                        }
                     }
                     else -> {
                         status_message("Tried to exit on not a chat room")
@@ -211,6 +235,20 @@ class MatrixInterface {
                     }
                 }
             }
+            is Action.NavigateToRoomInfo -> {
+                when (val _m = m) {
+                    is MatrixChatRoom -> {
+                        if(_m.room_type == "m.space") {
+                            status_message("Tried to navigate to room info when not in a room")
+                        } else {
+                            uistate.value = UiRoomInfo()
+                        }
+                    }
+                    else -> {
+                        status_message("Tried to navigate on not a chat room")
+                    }
+                }
+            }
         }
     }
 
@@ -218,6 +256,7 @@ class MatrixInterface {
         data class Refresh(val window_back: Int, val base_id: String?, val window_forward: Int): Action()
         data class ExitRoom(val v:Int = 1): Action()
         data class NavigateToRoom(val id: String): Action()
+        data class NavigateToRoomInfo(val unused:Int = 1): Action()
     }
 }
 

--- a/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/MatrixInterface.kt
+++ b/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/MatrixInterface.kt
@@ -39,6 +39,7 @@ class MatrixInterface {
     val sessions: MutableState<List<String>> = mutableStateOf(listOf())
     val pinned: MutableState<List<String>> = mutableStateOf(listOf())
     val members: MutableState<List<String>> = mutableStateOf(listOf())
+    val avatar: MutableState<String> = mutableStateOf("")
     val lock = ReentrantLock()
     val actions: MutableList<Action> = mutableListOf()
     var already_a_background_thread_running = false
@@ -57,6 +58,7 @@ class MatrixInterface {
                 sessions.value = _m.getSessions()
                 pinned.value = listOf()
                 members.value = listOf()
+                avatar.value = ""
             }
             is MatrixChatRoom -> {
                 messages.value = _m.messages
@@ -67,6 +69,7 @@ class MatrixInterface {
                 sessions.value = listOf()
                 pinned.value = _m.pinned
                 members.value = _m.members
+                avatar.value = _m.avatar
             }
         }
     }

--- a/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/RoomInfo.kt
+++ b/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/RoomInfo.kt
@@ -1,6 +1,6 @@
 package xyz.room409.serif.serif_compose
 
-//import androidx.compose.foundation.Image
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -12,8 +12,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.paddingFrom
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.ui.res.loadImageBitmap
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.material.Button
+import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Divider
+import androidx.compose.material.LocalContentAlpha
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
@@ -29,8 +34,16 @@ import androidx.compose.material.OutlinedTextField
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.rememberScrollbarAdapter
+import androidx.compose.foundation.VerticalScrollbar
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.HorizontalScrollbar
+import androidx.compose.foundation.horizontalScroll
 
 import androidx.compose.ui.ExperimentalComposeUiApi
+import java.io.File
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
@@ -46,64 +59,108 @@ fun RoomInfoContent(
     var current_room_topic by remember { mutableStateOf(uiState.roomTopic) }
     var room_name by remember { mutableStateOf(TextFieldValue(uiState.channelName)) }
     var room_topic by remember { mutableStateOf(TextFieldValue(uiState.roomTopic)) }
-    Surface(modifier = Modifier) {
-        Box(modifier = Modifier.fillMaxSize()) {
-            Column(Modifier.fillMaxSize()) {
-                Spacer(modifier = Modifier.height(74.dp))
+    val avatar_url by remember { mutableStateOf(uiState.roomAvatarUrl) }
+    Surface(modifier = Modifier.fillMaxSize()) {
+        Box(modifier = Modifier.fillMaxSize().padding(10.dp)) {
 
-                // List of Room Configuration Items
-                Button( onClick = onBackPressed) { Text("Back") }
-                Text(text = "Room Settings")
+            val scrollStateV = rememberScrollState(0)
+            val scrollStateH = rememberScrollState(0)
 
-                Divider(modifier = Modifier.padding(32.dp))
-                Text("[Placeholder for Room Icon]")
-                Divider(modifier = Modifier.padding(32.dp))
+            Box(modifier = Modifier.fillMaxSize()
+                .verticalScroll(scrollStateV)
+                .padding(end = 12.dp, bottom = 12.dp)
+                .horizontalScroll(scrollStateH)
+            ) {
 
-                Text("Room Name")
-                OutlinedTextField(
-                    value = room_name,
-                    singleLine = true,
-                    modifier = Modifier.padding(8.dp).fillMaxWidth(),
-                    label = { Text(text = current_room_name) },
-                    placeholder = { Text(text = "Super Secret Club") },
-                    onValueChange = { room_name = it },
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text)
-                )
-                Button(onClick = {
-                    runInViewModel { inter -> 
-                            //Don't allow empty room name
-                            //Also only send out requests if the data has changed
-                            if((room_name.text != "") && (room_name.text != current_room_name)) { inter.setRoomName(room_name.text) }
-                            else { { -> } }
+                Column {
+                    Spacer(modifier = Modifier.height(74.dp))
+                    // List of Room Configuration Items
+                    if(avatar_url != "") {
+                        val avatar_file = File(avatar_url)
+                        val img_bitmap = avatar_file.inputStream().buffered().use(::loadImageBitmap)
+                        Image(
+                            painter = BitmapPainter(img_bitmap),
+                            contentDescription = "Room Profile Picture",
+                            modifier = Modifier.fillMaxSize()
+                        )
+                    } else {
+                        Text("[No Room Profile Picture]")
                     }
-                }) { Text("Save") }
-                Text("Room Topic")
-                OutlinedTextField(
-                    value = room_topic,
-                    singleLine = true,
-                    modifier = Modifier.padding(8.dp).fillMaxWidth(),
-                    label = { Text(text = current_room_topic) },
-                    placeholder = { Text(text = "Room Topic or Description") },
-                    onValueChange = { room_topic = it },
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text)
-                )
-                Button(onClick = {
-                    runInViewModel { inter -> 
-                            //Only send out requests if the data has changed
-                            if(room_topic.text != current_room_topic) { inter.setRoomTopic(room_topic.text) }
-                            else { { -> } }
-                    }
-                }) { Text("Save") }
+                    Divider(modifier = Modifier.padding(32.dp))
 
-                Divider(modifier = Modifier.padding(16.dp))
-                Text(
-                    text = "Member list",
-                    style = MaterialTheme.typography.caption
-                )
-                for(member in uiState.members) {
-                    Text("[User Avatar] $member")
+                    Text("Room Name")
+                    OutlinedTextField(
+                        value = room_name,
+                        singleLine = true,
+                        modifier = Modifier.padding(8.dp).fillMaxWidth(),
+                        label = { Text(text = current_room_name) },
+                        placeholder = { Text(text = "Super Secret Club") },
+                        onValueChange = { room_name = it },
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text)
+                    )
+                    Button(onClick = {
+                        runInViewModel { inter ->
+                                //Don't allow empty room name
+                                //Also only send out requests if the data has changed
+                                if((room_name.text != "") && (room_name.text != current_room_name)) { inter.setRoomName(room_name.text) }
+                                else { { -> } }
+                        }
+                    }) { Text("Save") }
+                    Text("Room Topic")
+                    OutlinedTextField(
+                        value = room_topic,
+                        singleLine = true,
+                        modifier = Modifier.padding(8.dp).fillMaxWidth(),
+                        label = { Text(text = current_room_topic) },
+                        placeholder = { Text(text = "Room Topic or Description") },
+                        onValueChange = { room_topic = it },
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text)
+                    )
+                    Button(onClick = {
+                        runInViewModel { inter ->
+                                //Only send out requests if the data has changed
+                                if(room_topic.text != current_room_topic) { inter.setRoomTopic(room_topic.text) }
+                                else { { -> } }
+                        }
+                    }) { Text("Save") }
+
+                    Divider(modifier = Modifier.padding(16.dp))
+                    Text(
+                        text = "Member list",
+                        style = MaterialTheme.typography.caption
+                    )
+                    for(member in uiState.members) {
+                        Text("[User Avatar] $member")
+                    }
                 }
             }
+            VerticalScrollbar(
+                modifier = Modifier.align(Alignment.CenterEnd).fillMaxHeight(),
+                adapter = rememberScrollbarAdapter(scrollStateV)
+            )
+            HorizontalScrollbar(
+                modifier = Modifier.align(Alignment.BottomStart).fillMaxWidth(),
+                adapter = rememberScrollbarAdapter(scrollStateH)
+            )
+            JetchatAppBar(
+                modifier = modifier,
+                title = {
+                    Column(
+                        modifier = Modifier.weight(1f),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Text(
+                            text = "Room Settings",
+                            style = MaterialTheme.typography.subtitle1
+                        )
+                    }
+                },
+                actions = {
+                    CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
+                        Button( onClick = onBackPressed) { Text("Back") }
+                    }
+                }
+            )
         }
     }
 }

--- a/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/RoomInfo.kt
+++ b/serif_compose/src/commonMain/kotlin/xyz/room409/serif/serif_compose/RoomInfo.kt
@@ -1,0 +1,110 @@
+package xyz.room409.serif.serif_compose
+
+//import androidx.compose.foundation.Image
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.paddingFrom
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Button
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.foundation.layout.fillMaxWidth
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+fun RoomInfoContent(
+    uiState: ConversationUiState,
+    runInViewModel: ((MatrixInterface) -> (() -> Unit)) -> Unit,
+    modifier: Modifier = Modifier,
+    uiInputModifier: Modifier = Modifier
+)
+{
+    val onBackPressed = { -> runInViewModel { inter -> inter.exitRoom() } }
+    var current_room_name by remember { mutableStateOf(uiState.channelName) }
+    var current_room_topic by remember { mutableStateOf(uiState.roomTopic) }
+    var room_name by remember { mutableStateOf(TextFieldValue(uiState.channelName)) }
+    var room_topic by remember { mutableStateOf(TextFieldValue(uiState.roomTopic)) }
+    Surface(modifier = Modifier) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            Column(Modifier.fillMaxSize()) {
+                Spacer(modifier = Modifier.height(74.dp))
+
+                // List of Room Configuration Items
+                Button( onClick = onBackPressed) { Text("Back") }
+                Text(text = "Room Settings")
+
+                Divider(modifier = Modifier.padding(32.dp))
+                Text("[Placeholder for Room Icon]")
+                Divider(modifier = Modifier.padding(32.dp))
+
+                Text("Room Name")
+                OutlinedTextField(
+                    value = room_name,
+                    singleLine = true,
+                    modifier = Modifier.padding(8.dp).fillMaxWidth(),
+                    label = { Text(text = current_room_name) },
+                    placeholder = { Text(text = "Super Secret Club") },
+                    onValueChange = { room_name = it },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text)
+                )
+                Button(onClick = {
+                    runInViewModel { inter -> 
+                            //Don't allow empty room name
+                            //Also only send out requests if the data has changed
+                            if((room_name.text != "") && (room_name.text != current_room_name)) { inter.setRoomName(room_name.text) }
+                            else { { -> } }
+                    }
+                }) { Text("Save") }
+                Text("Room Topic")
+                OutlinedTextField(
+                    value = room_topic,
+                    singleLine = true,
+                    modifier = Modifier.padding(8.dp).fillMaxWidth(),
+                    label = { Text(text = current_room_topic) },
+                    placeholder = { Text(text = "Room Topic or Description") },
+                    onValueChange = { room_topic = it },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text)
+                )
+                Button(onClick = {
+                    runInViewModel { inter -> 
+                            //Only send out requests if the data has changed
+                            if(room_topic.text != current_room_topic) { inter.setRoomTopic(room_topic.text) }
+                            else { { -> } }
+                    }
+                }) { Text("Save") }
+
+                Divider(modifier = Modifier.padding(16.dp))
+                Text(
+                    text = "Member list",
+                    style = MaterialTheme.typography.caption
+                )
+                for(member in uiState.members) {
+                    Text("[User Avatar] $member")
+                }
+            }
+        }
+    }
+}
+

--- a/serif_compose_desktop/src/main/kotlin/main.kt
+++ b/serif_compose_desktop/src/main/kotlin/main.kt
@@ -74,6 +74,8 @@ class FakeViewModel {
         get() = inter.pinned
     val members: MutableState<List<String>>
         get() = inter.members
+    val avatar: MutableState<String>
+        get() = inter.avatar
 }
 
 
@@ -100,7 +102,8 @@ fun main() = application {
                         fakeViewModel.roomName.value,
                         fakeViewModel.ourUserId.value, 0, fakeViewModel.messages.value.reversed(),
                         fakeViewModel.pinned.value, fakeViewModel.members.value,
-                        fakeViewModel.roomTopic.value),
+                        fakeViewModel.roomTopic.value,
+                        fakeViewModel.avatar.value),
                     runInViewModel = { fakeViewModel.runInViewModel(it) },
                 )
             } else {

--- a/serif_compose_desktop/src/main/kotlin/main.kt
+++ b/serif_compose_desktop/src/main/kotlin/main.kt
@@ -64,12 +64,16 @@ class FakeViewModel {
         get() = inter.roomPath
     val roomName: MutableState<String>
         get() = inter.roomName
+    val roomTopic: MutableState<String>
+        get() = inter.roomTopic
     val sessions: MutableState<List<String>>
         get() = inter.sessions
     val uistate: MutableState<UiScreenState>
         get() = inter.uistate
     val pinned: MutableState<List<String>>
         get() = inter.pinned
+    val members: MutableState<List<String>>
+        get() = inter.members
 }
 
 
@@ -90,10 +94,23 @@ fun main() = application {
                     sessions = fakeViewModel.sessions.value,
                     loginMessage = ((fakeViewModel.uistate.value) as UiLogin).message
                 )
+            } else if(fakeViewModel.uistate.value is UiRoomInfo) {
+                RoomInfoContent(
+                    uiState = ConversationUiState(
+                        fakeViewModel.roomName.value,
+                        fakeViewModel.ourUserId.value, 0, fakeViewModel.messages.value.reversed(),
+                        fakeViewModel.pinned.value, fakeViewModel.members.value,
+                        fakeViewModel.roomTopic.value),
+                    runInViewModel = { fakeViewModel.runInViewModel(it) },
+                )
             } else {
                 ConversationContent(
                     bumpWindowBase = { idx -> fakeViewModel.bumpWindow(idx?.let { idx -> fakeViewModel.messages.value.reversed().let { messages -> messages[min(idx, messages.size-1)].id } }); },
-                    uiState = ConversationUiState(fakeViewModel.roomName.value, fakeViewModel.ourUserId.value, 0, fakeViewModel.messages.value.reversed(), fakeViewModel.pinned.value),
+                    uiState = ConversationUiState(
+                        fakeViewModel.roomName.value,
+                        fakeViewModel.ourUserId.value, 0, fakeViewModel.messages.value.reversed(),
+                        fakeViewModel.pinned.value, fakeViewModel.members.value,
+                        fakeViewModel.roomTopic.value),
                     runInViewModel = { fakeViewModel.runInViewModel(it) },
                     navigateToProfile = { user -> println("clicked on user $user"); },
                     onNavIconPressed = { println("Pressed nav icon..."); },


### PR DESCRIPTION
Fixes #127 

Adds in a dedicated screen to display room meta data, including avatar, name, description, and member list. Allows setting of name and description. This also gets very initial support for images which will be expanded upon in a later PR focused on image support. Not tested on android.